### PR TITLE
always close with a numeric code

### DIFF
--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -1,7 +1,7 @@
 import { merge } from './Utils';
 
 import { Client, generateId, isValidId } from './index';
-import { IpcProtocol } from './Protocol';
+import { IpcProtocol, WS_CLOSE_CONSENTED } from './Protocol';
 
 import { RegisteredHandler } from './matchmaker/RegisteredHandler';
 import { Room, RoomAvailable, RoomConstructor } from './Room';
@@ -60,7 +60,7 @@ export class MatchMaker {
           client.send(new Buffer(data), { binary: true });
 
         } else if (method === 'close') {
-          client.close(data || undefined);
+          client.close(WS_CLOSE_CONSENTED, data || undefined);
         }
       });
 


### PR DESCRIPTION
per https://github.com/websockets/ws/blob/5d90141505dc41c129ab5d5228e37d49979d7541/lib/sender.js#L106-L127

code is the first argument, and if it's not a number, `ws` gets angry.