### PR TITLE
Allow client to force create a room on join

### DIFF
--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -1,4 +1,3 @@
-import * as WebSocket from 'ws';
 import { merge } from './Utils';
 
 import { Client, generateId, isValidId } from './index';
@@ -123,7 +122,8 @@ export class MatchMaker {
       await this.awaitRoomAvailable(roomToJoin);
 
       // check if there's an existing room with provided name available to join
-      if (hasHandler) {
+      // check if client forces a create, if he does, do not search for available room
+      if (hasHandler && !clientOptions.forceCreate) {
         const bestRoomByScore = (await this.getAvailableRoomByScore(roomToJoin, clientOptions))[0];
         if (bestRoomByScore && bestRoomByScore.roomId) {
           roomId = bestRoomByScore.roomId;


### PR DESCRIPTION
Basically, I took inspiration from the unity3d `ColyseusClient` which passes a `create` prop to the client options.

I renamed it to `forceCreate` to make it clear that it's going to create a room and not join an available one.

This doesn't affect the `rejoin` mechanism, since this is only done when the used it joining a room by the room name, and not room id, and he's not rejoining.