### PR TITLE
Fix schema type checking

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -117,3 +117,13 @@ export function logError(err: Error): void {
     debugAndPrintError(`websocket error: ${err.message}\n${err.stack}`);
   }
 }
+
+export function typeCheck(objectInstance: any, checkedClass: any): boolean {
+  while (objectInstance.__proto__) {
+    objectInstance = objectInstance.__proto__;
+    if (objectInstance.constructor.name === checkedClass.name) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/serializer/FossilDeltaSerializer.ts
+++ b/src/serializer/FossilDeltaSerializer.ts
@@ -8,6 +8,7 @@ import { Serializer } from './Serializer';
 
 import jsonPatch from 'fast-json-patch'; // this is only used for debugging patches
 import { debugPatch } from '../Debug';
+import { typeCheck } from '../Utils';
 
 export class FossilDeltaSerializer<T> implements Serializer<T> {
   public id = 'fossil-delta';
@@ -52,8 +53,8 @@ export class FossilDeltaSerializer<T> implements Serializer<T> {
     /**
      * allow optimized state changes when using `Schema` class.
      */
-    if (newState instanceof Schema) {
-      if (newState.$changed) {
+    if (typeCheck(newState, Schema)) {
+      if ((newState as Schema).$changed) {
         changed = true;
         currentStateEncoded = msgpack.encode(currentState);
       }

--- a/src/serializer/SchemaSerializer.ts
+++ b/src/serializer/SchemaSerializer.ts
@@ -3,6 +3,7 @@ import { Serializer } from './Serializer';
 
 import { Definition, Reflection, Schema } from '@colyseus/schema';
 import { Protocol, send } from '../Protocol';
+import { typeCheck } from '../Utils';
 
 export class SchemaSerializer<T> implements Serializer<T> {
   public id = 'schema';
@@ -10,7 +11,7 @@ export class SchemaSerializer<T> implements Serializer<T> {
   private hasFiltersByClient: boolean = false;
 
   public reset(newState: T & Schema) {
-    if (!(newState instanceof Schema)) {
+    if (!typeCheck(newState, Schema)) {
       throw new Error(`SchemaSerializer error. See: https://docs.colyseus.io/migrating/0.10/#new-default-serializer`);
     }
     this.state = newState;


### PR DESCRIPTION
Fixes: https://github.com/colyseus/colyseus/issues/231

The problem is that `instanceof` does not work when the origin of the checked class is different then the one the instance was created with.

Using constructor names to replace `instanceof` is reliable as long as the name is unique enough (to avoid naming colisions), which I think `Schema` is.