### PR TITLE
fix: typing of setState argument

### DIFF
--- a/src/Room.ts
+++ b/src/Room.ts
@@ -150,7 +150,7 @@ export abstract class Room<T= any> extends EventEmitter {
     }
   }
 
-  public setState(newState) {
+  public setState(newState: T) {
     this.clock.start();
 
     this._serializer.reset(newState);


### PR DESCRIPTION
There was an issue wherein the created typing for the setState method would accept any state instead of T. This commit should fix this.