### PR TITLE
Move onJoin call after connection resolved

### DIFF
--- a/src/Room.ts
+++ b/src/Room.ts
@@ -321,9 +321,6 @@ export abstract class Room<T= any> extends EventEmitter {
           throw new Error('onAuth failed.');
         }
 
-        if (this.onJoin) {
-          await this.onJoin(client, options, client.auth);
-        }
       } catch (e) {
         debugAndPrintError(e);
         throw e;
@@ -361,6 +358,10 @@ export abstract class Room<T= any> extends EventEmitter {
 
     // joined successfully, add to local client list
     this.clients.push(client);
+
+    if(!reconnection && this.onJoin) {
+        await this.onJoin(client, options, client.auth);
+    }
   }
 
   protected _getSerializer?(): Serializer<T> {


### PR DESCRIPTION
This resolves #260 

I moved the `onJoin` call to be after all other connection logic. I tested this to see if it works and broadcast now sends to the client that just connected and all other clients from within `onJoin`. Also, `clients.length` now returns the correct number from within the `onJoin` function.

If someone was relying on the length number being wrong then this would be a breaking change for them. 