### PR TITLE
Allow to limit the number of rooms a process can spawn closes #155

### DIFF
--- a/src/Protocol.ts
+++ b/src/Protocol.ts
@@ -28,6 +28,7 @@ export enum Protocol {
   ERR_MATCHMAKE_INVALID_ROOM_ID = 4212,
   ERR_MATCHMAKE_UNHANDLED = 4213, // generic exception during onCreate/onJoin
   ERR_MATCHMAKE_EXPIRED = 4214, // generic exception during onCreate/onJoin
+  ERR_MATCHMAKE_INSTANCE_LIMIT = 4215
 }
 
 // Inter-process communication protocol

--- a/src/matchmaker/RegisteredHandler.ts
+++ b/src/matchmaker/RegisteredHandler.ts
@@ -17,21 +17,25 @@ export const INVALID_OPTION_KEYS: Array<keyof RoomListingData> = [
 export interface SortOptions { [fieldName: string]: 1 | -1 | 'asc' | 'desc' | 'ascending' | 'descending'; }
 
 export class RegisteredHandler extends EventEmitter {
-  public klass: RoomConstructor;
-  public options: any;
-
   public filterOptions: string[] = [];
   public sortOptions?: SortOptions;
+  public instanceLimit: number;
+  public instanceCount: number = 0;
 
-  constructor(klass: RoomConstructor, options: any) {
+  constructor(
+    public klass: RoomConstructor,
+    public options: any
+  ) {
     super();
-
-    this.klass = klass;
-    this.options = options;
   }
 
   public filterBy(options: string[]) {
     this.filterOptions = options;
+    return this;
+  }
+
+  public maxInstances(value: number) {
+    this.instanceLimit = value;
     return this;
   }
 
@@ -53,5 +57,9 @@ export class RegisteredHandler extends EventEmitter {
       }
       return prev;
     }, {});
+  }
+
+  public isAvailableInstantiation() {
+    return this.instanceLimit == null || this.instanceCount < this.instanceLimit;
   }
 }


### PR DESCRIPTION
Hi,

I added an instanceCount variable in RegisteredHandler to store the number of instances created for a given room. Then I could check if a new room exceeds the maximum instance number defined in instanceLimit.