### PR TITLE
[0.12.x] Unit tests for SchemaSerializer (recursiveness)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 yarn.lock
 /lib
 .DS_Store
+
+.nyc_output
+coverage

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Tests Current TS File",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-r",
+        "ts-node/register",
+        "${relativeFile}"
+      ],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector"
+    }
+  ]
+}

--- a/test/SchemaSerializerTest.ts
+++ b/test/SchemaSerializerTest.ts
@@ -25,39 +25,37 @@ describe("SchemaSerializer", () => {
       assert.ok(serializer.hasFilter(State._schema, State._filters));
     });
 
-    it("should identify filter on recursive structures", () => {
-      class Deck extends Schema {
-        @filter(function(client, value, root) {
-          return true;
-        })
-        @type([Deck]) decks = new ArraySchema<Deck>();
-      }
+    it("should be able to navigate on recursive structures", () => {
+      class Container extends Schema {
+        @type("string") name: string;
 
-      class Card extends Deck {
-        @type([Deck]) moreDecks = new ArraySchema<Deck>();
-        @type(Card) card: Card;
+        @type([Container]) arrayOfContainers: ArraySchema<Container>;
+        @type({ map: Container }) mapOfContainers: MapSchema<Container>;
       }
-
-      class Hand extends Schema {
-        @type([Card]) cards = new ArraySchema<Card>();
-        @type(Deck) deck = new Deck();
-      }
-
-      class Player extends Schema {
-        @type(Hand) hand = new Hand();
-        @type(Deck) deck = new Deck();
-      }
-
       class State extends Schema {
-        @type(Card) card: Card;
-        @type(Deck) deck = new Deck();
-        @type({map: Player}) players = new MapSchema<Player>();
+        @type(Container) root: Container;
       }
 
-      assert.ok(serializer.hasFilter(State._schema, State._filters));
+      const fun = () => serializer.hasFilter(State._schema, State._filters);
+
+      assert.doesNotThrow(fun);
+      assert.equal(false, fun());
     });
 
+    it("should be able to navigate on maps and arrays of primitive types", () => {
+      class State extends Schema {
+        @type(["string"]) stringArr: MapSchema<string>;
+        @type(["number"]) numberArr: MapSchema<number>;
+        @type(["boolean"]) booleanArr: MapSchema<boolean>;
+        @type({ map: "string" }) stringMap: MapSchema<string>;
+        @type({ map: "number" }) numberMap: MapSchema<number>;
+        @type({ map: "boolean" }) booleanMap: MapSchema<boolean>;
+      }
+
+      const fun = () => serializer.hasFilter(State._schema, State._filters);
+
+      assert.doesNotThrow(fun);
+      assert.equal(false, fun());
+    });
   });
-
-
 });


### PR DESCRIPTION
I've narrowed your test down to simply "try navigating in recursive structure".

And second failing test as a bonus, which I also found in my game. The issue may lie in here:
```
// SchemaSerializer.ts:94
const childSchema = (schema[fieldName][0] as typeof Schema)._schema;
```
For a map of strings, its trying to get `_schema` property of primitive value (eg. string) -> undefined, and inside the next `this.hasFilter(undefined, undefined)` it breaks.

+ git ignore coverage reports
+ easier tests debugging in vscode