### PR TITLE
Spawn rooms on remote processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus",
-  "version": "0.12.0",
+  "version": "0.12.1-alpha.0",
   "description": "Multiplayer Game Server for Node.js.",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/IPC.ts
+++ b/src/IPC.ts
@@ -1,0 +1,78 @@
+import { debugAndPrintError } from './Debug';
+import { Presence } from './presence/Presence';
+import { IpcProtocol } from './Protocol';
+import { generateId, REMOTE_ROOM_SHORT_TIMEOUT } from './Utils';
+
+export async function requestFromIPC<T>(
+  presence: Presence,
+  publishToChannel: string,
+  method: string,
+  args: any[],
+  rejectionTimeout: number = REMOTE_ROOM_SHORT_TIMEOUT,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let unsubscribeTimeout: NodeJS.Timer;
+
+    const requestId = generateId();
+    const channel = `ipc:${requestId}`;
+
+    const unsubscribe = () => {
+      presence.unsubscribe(channel);
+      clearTimeout(unsubscribeTimeout);
+    };
+
+    presence.subscribe(channel, (message) => {
+      const [code, data] = message;
+      if (code === IpcProtocol.SUCCESS) {
+        resolve(data);
+      } else if (code === IpcProtocol.ERROR) {
+        reject(data);
+      }
+      unsubscribe();
+    });
+
+    presence.publish(publishToChannel, [method, requestId, args]);
+
+    unsubscribeTimeout = setTimeout(() => {
+      unsubscribe();
+      reject(`IPC timed out. method: ${method}, args: ${JSON.stringify(args)}`);
+    }, rejectionTimeout);
+  });
+}
+
+export async function subscribeIPC(
+  presence: Presence,
+  processId: string,
+  channel: string,
+  replyCallback: (method: string, args: any[]) => any,
+) {
+  await presence.subscribe(channel, (message) => {
+    const [method, requestId, args] = message;
+
+    const reply = (code, data) => {
+      presence.publish(`ipc:${requestId}`, [code, data]);
+    };
+
+    // reply with method result
+    let response: any;
+    try {
+      response = replyCallback(method, args);
+
+    } catch (e) {
+      debugAndPrintError(e);
+      return reply(IpcProtocol.ERROR, e.message || e);
+    }
+
+    if (!(response instanceof Promise)) {
+      return reply(IpcProtocol.SUCCESS, response);
+    }
+
+    response.
+      then((result) => reply(IpcProtocol.SUCCESS, result)).
+      catch((e) => {
+        // user might have called `reject()` without arguments.
+        const err = e && e.message || e;
+        reply(IpcProtocol.ERROR, err);
+      });
+  });
+}

--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -1,7 +1,7 @@
-import { merge, retry } from './Utils';
+import { Client, Protocol } from './Protocol';
 
-import { Client, generateId } from './index';
-import { IpcProtocol, Protocol } from './Protocol';
+import { requestFromIPC, subscribeIPC } from './IPC';
+import { generateId, merge, REMOTE_ROOM_SHORT_TIMEOUT, retry } from './Utils';
 
 import { RegisteredHandler } from './matchmaker/RegisteredHandler';
 import { Room, RoomConstructor, RoomInternalState } from './Room';
@@ -24,11 +24,6 @@ export interface SeatReservation {
   room: RoomListingData;
 }
 
-// remote room call timeouts
-export const REMOTE_ROOM_SHORT_TIMEOUT = Number(process.env.COLYSEUS_PRESENCE_SHORT_TIMEOUT || 2000);
-
-type RemoteRoomResponse<T= any> = [string?, T?];
-
 const handlers: {[id: string]: RegisteredHandler} = {};
 const rooms: {[roomId: string]: Room} = {};
 
@@ -43,6 +38,15 @@ export function setup(_presence?: Presence, _driver?: MatchMakerDriver, _process
   driver = _driver || new LocalDriver();
   processId = _processId;
   isGracefullyShuttingDown = false;
+
+  /**
+   * Subscribe to remote `handleCreateRoom` calls.
+   */
+  subscribeIPC(presence, processId, getProcessChannel(), (_, args) => {
+    return handleCreateRoom.apply(undefined, args);
+  });
+
+  presence.hset(getRoomCountKey(), processId, '0');
 }
 
 /**
@@ -94,7 +98,7 @@ export async function joinById(roomId: string, options: ClientOptions = {}) {
 
     if (rejoinSessionId) {
       // handle re-connection!
-      const [_, hasReservedSeat] = await remoteRoomCall(room.roomId, 'hasReservedSeat', [rejoinSessionId]);
+      const hasReservedSeat = await remoteRoomCall(room.roomId, 'hasReservedSeat', [rejoinSessionId]);
 
       if (hasReservedSeat) {
         return { room, sessionId: rejoinSessionId };
@@ -158,50 +162,25 @@ export async function remoteRoomCall<R= any>(
   method: string,
   args?: any[],
   rejectionTimeout = REMOTE_ROOM_SHORT_TIMEOUT,
-): Promise<RemoteRoomResponse<R>> {
+): Promise<R> {
   const room = rooms[roomId];
 
   if (!room) {
-    return new Promise((resolve, reject) => {
-      let unsubscribeTimeout: NodeJS.Timer;
+    try {
+      return await requestFromIPC<R>(presence, getRoomChannel(roomId), method, args);
 
-      const requestId = generateId();
-      const channel = `${roomId}:${requestId}`;
-
-      const unsubscribe = () => {
-        presence.unsubscribe(channel);
-        clearTimeout(unsubscribeTimeout);
-      };
-
-      presence.subscribe(channel, (message) => {
-        const [code, data] = message;
-        if (code === IpcProtocol.SUCCESS) {
-          resolve(data);
-
-        } else if (code === IpcProtocol.ERROR) {
-          reject(data);
-        }
-        unsubscribe();
-      });
-
-      presence.publish(getRoomChannel(roomId), [method, requestId, args]);
-
-      unsubscribeTimeout = setTimeout(() => {
-        unsubscribe();
-
-        const request = `${method}${ args && ' with args ' + JSON.stringify(args) || '' }`;
-        reject(new Error(`remote room (${roomId}) timed out, requesting "${request}". ` +
-          `Timeout setting: ${rejectionTimeout}ms`));
-      }, rejectionTimeout);
-    });
+    } catch (e) {
+      const request = `${method}${args && ' with args ' + JSON.stringify(args) || ''}`;
+      throw new MatchMakeError(
+        `remote room (${roomId}) timed out, requesting "${request}". (${rejectionTimeout}ms exceeded)`,
+        Protocol.ERR_MATCHMAKE_UNHANDLED,
+      );
+    }
 
   } else {
-    return [
-      processId,
-      (!args && typeof (room[method]) !== 'function')
+    return (!args && typeof (room[method]) !== 'function')
         ? room[method]
-        : (await room[method].apply(room, args)),
-    ];
+        : (await room[method].apply(room, args));
   }
 }
 
@@ -228,6 +207,52 @@ export function hasHandler(name: string) {
  * Create a room
  */
 export async function createRoom(roomName: string, clientOptions: ClientOptions): Promise<RoomListingData> {
+  const roomsSpawnedByProcessId = await presence.hgetall(getRoomCountKey());
+
+  const processIdWithFewerRooms = (
+    Object.keys(roomsSpawnedByProcessId).sort((p1, p2) => {
+      return (roomsSpawnedByProcessId[p1] > roomsSpawnedByProcessId[p2])
+        ? 1
+        : -1;
+    })[0]
+  ) || processId;
+
+  if (processIdWithFewerRooms === processId) {
+    // create the room on this process!
+    return await handleCreateRoom(roomName, clientOptions);
+
+  } else {
+    // ask other process to create the room!
+    let room: RoomListingData;
+
+    try {
+      room = await createRemoteRoom(processIdWithFewerRooms, roomName, clientOptions);
+
+    } catch (e) {
+      debugAndPrintError(e);
+      room = await handleCreateRoom(roomName, clientOptions);
+    }
+
+    return room;
+  }
+}
+
+async function createRemoteRoom(
+  remoteProcessId: string,
+  roomName: string,
+  clientOptions: ClientOptions,
+  rejectionTimeout = REMOTE_ROOM_SHORT_TIMEOUT,
+): Promise<RoomListingData> {
+  return await requestFromIPC<RoomListingData>(
+    presence,
+    getProcessChannel(remoteProcessId),
+    undefined,
+    [roomName, clientOptions],
+    rejectionTimeout,
+  );
+}
+
+async function handleCreateRoom(roomName: string, clientOptions: ClientOptions): Promise<RoomListingData> {
   const registeredHandler = handlers[roomName];
 
   if (!registeredHandler) {
@@ -251,6 +276,9 @@ export async function createRoom(roomName: string, clientOptions: ClientOptions)
   if (room.onCreate) {
     try {
       await room.onCreate(merge({}, clientOptions, registeredHandler.options));
+
+      // increment amount of rooms this process is handling
+      presence.hincrby(getRoomCountKey(), processId, 1);
 
     } catch (e) {
       debugAndPrintError(e);
@@ -293,6 +321,14 @@ export function gracefullyShutdown(): Promise<any> {
 
   isGracefullyShuttingDown = true;
 
+  debugMatchMaking(`${processId} is shutting down!`);
+
+  // remove processId from room count key
+  presence.hdel(getRoomCountKey(), processId);
+
+  // unsubscribe from process id channel
+  presence.unsubscribe(getProcessChannel());
+
   const promises: Array<Promise<any>> = [];
 
   for (const roomId in rooms) {
@@ -319,10 +355,10 @@ export async function reserveSeatFor(room: RoomListingData, options: any) {
   let successfulSeatReservation: boolean;
 
   try {
-    const [_, ok] = await remoteRoomCall(room.roomId, '_reserveSeat', [sessionId, options]);
-    successfulSeatReservation = ok;
+    successfulSeatReservation = await remoteRoomCall(room.roomId, '_reserveSeat', [sessionId, options]);
 
   } catch (e) {
+    debugMatchMaking(e);
     successfulSeatReservation = false;
   }
 
@@ -360,52 +396,23 @@ async function cleanupStaleRooms(roomName: string) {
 async function createRoomReferences(room: Room, init: boolean = false): Promise<boolean> {
   rooms[room.roomId] = room;
 
-  // add unlocked room reference
-  await presence.sadd(room.roomName, room.roomId);
-
   if (init) {
-    await presence.subscribe(getRoomChannel(room.roomId), (message) => {
-      const [method, requestId, args] = message;
-
-      const reply = (code, data) => {
-        presence.publish(`${room.roomId}:${requestId}`, [code, [processId, data]]);
-      };
-
-      // reply with property value
-      if (!args && typeof (room[method]) !== 'function') {
-        return reply(IpcProtocol.SUCCESS, room[method]);
-      }
-
-      // reply with method result
-      let response: any;
-      try {
-        response = room[method].apply(room, args);
-
-      } catch (e) {
-        debugAndPrintError(e);
-        return reply(IpcProtocol.ERROR, e.message || e);
-      }
-
-      if (!(response instanceof Promise)) {
-        return reply(IpcProtocol.SUCCESS, response);
-      }
-
-      response.
-        then((result) => reply(IpcProtocol.SUCCESS, result)).
-        catch((e) => {
-          // user might have called `reject()` without arguments.
-          const err = e && e.message || e;
-          reply(IpcProtocol.ERROR, err);
-        });
-    });
+    await subscribeIPC(
+      presence,
+      processId,
+      getRoomChannel(room.roomId),
+      (method, args) => {
+        return (!args && typeof (room[method]) !== 'function')
+          ? room[method]
+          : room[method].apply(room, args);
+      },
+    );
   }
 
   return true;
 }
 
 function clearRoomReferences(room: Room) {
-  presence.srem(room.roomName, room.roomId);
-
   // clear list of connecting clients.
   presence.del(room.roomId);
 }
@@ -445,7 +452,15 @@ function getRoomChannel(roomId: string) {
 }
 
 function getHandlerConcurrencyKey(name: string) {
-  return `${name}:c`;
+  return `c:${name}`;
+}
+
+function getProcessChannel(id: string = processId) {
+  return `p:${id}`;
+}
+
+function getRoomCountKey() {
+  return 'roomcount';
 }
 
 function onClientJoinRoom(room: Room, client: Client) {
@@ -473,6 +488,11 @@ async function unlockRoom(roomName: string, room: Room) {
 
 function disposeRoom(roomName: string, room: Room): void {
   debugMatchMaking('disposing \'%s\' (%s) on processId \'%s\'', roomName, room.roomId, processId);
+
+  // decrease amount of rooms this process is handling
+  if (!isGracefullyShuttingDown) {
+    presence.hincrby(getRoomCountKey(), processId, -1);
+  }
 
   // remove from room listing
   room.listing.remove();

--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -226,30 +226,22 @@ export async function createRoom(roomName: string, clientOptions: ClientOptions)
     let room: RoomListingData;
 
     try {
-      room = await createRemoteRoom(processIdWithFewerRooms, roomName, clientOptions);
+      room = await requestFromIPC<RoomListingData>(
+        presence,
+        getProcessChannel(processIdWithFewerRooms),
+        undefined,
+        [roomName, clientOptions],
+        REMOTE_ROOM_SHORT_TIMEOUT,
+      );
 
     } catch (e) {
+      // if other process failed to respond, create the room on this process
       debugAndPrintError(e);
       room = await handleCreateRoom(roomName, clientOptions);
     }
 
     return room;
   }
-}
-
-async function createRemoteRoom(
-  remoteProcessId: string,
-  roomName: string,
-  clientOptions: ClientOptions,
-  rejectionTimeout = REMOTE_ROOM_SHORT_TIMEOUT,
-): Promise<RoomListingData> {
-  return await requestFromIPC<RoomListingData>(
-    presence,
-    getProcessChannel(remoteProcessId),
-    undefined,
-    [roomName, clientOptions],
-    rejectionTimeout,
-  );
 }
 
 async function handleCreateRoom(roomName: string, clientOptions: ClientOptions): Promise<RoomListingData> {

--- a/src/Protocol.ts
+++ b/src/Protocol.ts
@@ -1,8 +1,8 @@
-import { Schema } from '@colyseus/schema';
+import http from 'http';
 import msgpack from 'notepack.io';
 import WebSocket from 'ws';
+
 import { debugAndPrintError } from './Debug';
-import { Client, ClientState } from './index';
 
 // Colyseus protocol codes range between 0~100
 export enum Protocol {
@@ -38,6 +38,26 @@ export enum IpcProtocol {
   ERROR = 1,
   TIMEOUT = 2,
 }
+
+export enum ClientState { JOINING, JOINED, RECONNECTED }
+
+// Export 'WebSocket' as 'Client' with 'id' property.
+export type Client = WebSocket & {
+  upgradeReq?: http.IncomingMessage; // cross-compatibility for ws (v3.x+) and uws
+  // id: string;
+
+  id: string;
+  sessionId: string; // TODO: remove sessionId on version 1.0.0
+
+  /**
+   * auth data provided by your `onAuth`
+   */
+  auth?: any;
+
+  pingCount: number; // ping / pong
+  state: ClientState;
+  _enqueuedMessages: any[];
+};
 
 export function decode(message: any) {
   try {

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -5,13 +5,12 @@ import { Schema } from '@colyseus/schema';
 import Clock from '@gamestdio/timer';
 import { EventEmitter } from 'events';
 
-import { Client, ClientState } from '.';
 import { Presence } from './presence/Presence';
 
 import { SchemaSerializer } from './serializer/SchemaSerializer';
 import { Serializer } from './serializer/Serializer';
 
-import { decode, Protocol, send } from './Protocol';
+import { Client, ClientState, decode, Protocol, send } from './Protocol';
 import { Deferred, spliceOne } from './Utils';
 
 import { debugAndPrintError, debugPatch } from './Debug';

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,6 +1,13 @@
-import querystring from 'querystring';
+import nanoid from 'nanoid';
 
-import { debugAndPrintError, debugMatchMaking } from './Debug';
+import { debugAndPrintError } from './Debug';
+
+// remote room call timeouts
+export const REMOTE_ROOM_SHORT_TIMEOUT = Number(process.env.COLYSEUS_PRESENCE_SHORT_TIMEOUT || 2000);
+
+export function generateId() {
+  return nanoid(9);
+}
 
 //
 // nodemon sends SIGUSR2 before reloading
@@ -89,27 +96,6 @@ export function spliceOne(arr: any[], index: number): boolean {
   return true;
 }
 
-export function parseQueryString(query: string): any {
-  const data = querystring.parse(query);
-
-  for (const k in data) {
-    if (!Object.prototype.hasOwnProperty.call(data, k)) { continue; }
-
-    let typedValue;
-
-    try {
-      typedValue = JSON.parse(data[k] as string);
-
-    } catch (e) {
-      typedValue = data[k];
-    }
-
-    data[k] = typedValue;
-  }
-
-  return data;
-}
-
 export function merge(a: any, ...objs: any[]): any {
   for (let i = 0, len = objs.length; i < len; i++) {
     const b = objs[i];
@@ -120,10 +106,4 @@ export function merge(a: any, ...objs: any[]): any {
     }
   }
   return a;
-}
-
-export function logError(err: Error): void {
-  if (err) {
-    debugAndPrintError(`websocket error: ${err.message}\n${err.stack}`);
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,9 @@
 import Clock, { Delayed } from '@gamestdio/timer';
-import http from 'http';
-import nanoid from 'nanoid';
-import WebSocket from 'ws';
 
 // Core classes
 export { Server } from './Server';
 export { Room } from './Room';
-export { Protocol } from './Protocol';
+export { Client, Protocol } from './Protocol';
 export { RegisteredHandler, SortOptions } from './matchmaker/RegisteredHandler';
 
 // MatchMaker
@@ -28,24 +25,4 @@ export { SchemaSerializer } from './serializer/SchemaSerializer';
 // Utilities
 export { Clock, Delayed };
 export { nonenumerable as nosync } from 'nonenumerable';
-export function generateId() { return nanoid(9); }
-
-export enum ClientState { JOINING, JOINED, RECONNECTED }
-
-// Export 'WebSocket' as 'Client' with 'id' property.
-export type Client = WebSocket & {
-  upgradeReq?: http.IncomingMessage; // cross-compatibility for ws (v3.x+) and uws
-  // id: string;
-
-  id: string;
-  sessionId: string; // TODO: remove sessionId on version 1.0.0
-
-  /**
-   * auth data provided by your `onAuth`
-   */
-  auth?: any;
-
-  pingCount: number; // ping / pong
-  state: ClientState;
-  _enqueuedMessages: any[];
-};
+export { generateId } from './Utils';

--- a/src/matchmaker/RegisteredHandler.ts
+++ b/src/matchmaker/RegisteredHandler.ts
@@ -26,6 +26,11 @@ export class RegisteredHandler extends EventEmitter {
   constructor(klass: RoomConstructor, options: any) {
     super();
 
+    if (typeof(klass) !== 'function') {
+      console.debug('You are likely not importing your room class correctly.');
+      throw new Error(`class is expected but ${typeof(klass)} was provided.`);
+    }
+
     this.klass = klass;
     this.options = options;
   }

--- a/src/presence/LocalPresence.ts
+++ b/src/presence/LocalPresence.ts
@@ -114,26 +114,33 @@ export class LocalPresence implements Presence {
       }, []);
     }
 
-    public hset(roomId: string, key: string, value: string) {
-        if (!this.hash[roomId]) {
-            this.hash[roomId] = {};
+    public hset(key: string, field: string, value: string) {
+        if (!this.hash[key]) { this.hash[key] = {}; }
+        this.hash[key][field] = value;
+    }
+
+    public hincrby(key: string, field: string, value: number) {
+        if (!this.hash[key]) { this.hash[key] = {}; }
+        const previousValue = Number(this.hash[key][field] || '0');
+        this.hash[key][field] = (previousValue + value).toString();
+    }
+
+    public async hget(key: string, field: string) {
+        return this.hash[key] && this.hash[key][field];
+    }
+
+    public async hgetall(key: string) {
+        return this.hash[key] || {};
+    }
+
+    public hdel(key: string, field: any) {
+        if (this.hash[key]) {
+            delete this.hash[key][field];
         }
-
-        this.hash[roomId][key] = value;
     }
 
-    public async hget(roomId: string, key: string) {
-        return this.hash[roomId] && this.hash[roomId][key];
-    }
-
-    public hdel(roomId: string, key: any) {
-        if (this.hash[roomId]) {
-            delete this.hash[roomId][key];
-        }
-    }
-
-    public async hlen(roomId: string) {
-        return this.hash[roomId] && Object.keys(this.hash[roomId]).length || 0;
+    public async hlen(key: string) {
+        return this.hash[key] && Object.keys(this.hash[key]).length || 0;
     }
 
     public async incr(key: string) {

--- a/src/presence/Presence.ts
+++ b/src/presence/Presence.ts
@@ -15,10 +15,12 @@ export interface Presence {
     scard(key: string);
     sinter(...keys: string[]): Promise<string[]>;
 
-    hset(roomId: string, key: string, value: string);
-    hget(roomId: string, key: string): Promise<string>;
-    hdel(roomId: string, key: string);
-    hlen(roomId: string): Promise<number>;
+    hset(key: string, field: string, value: string);
+    hincrby(key: string, field: string, value: number);
+    hget(key: string, field: string): Promise<string>;
+    hgetall(key: string): Promise<{ [key: string]: string }>;
+    hdel(key: string, field: string);
+    hlen(key: string): Promise<number>;
 
     incr(key: string);
     decr(key: string);

--- a/src/presence/RedisPresence.ts
+++ b/src/presence/RedisPresence.ts
@@ -142,24 +142,42 @@ export class RedisPresence implements Presence {
         });
     }
 
-    public async hset(roomId: string, key: string, value: string) {
+    public async hset(key: string, field: string, value: string) {
         return new Promise((resolve) => {
-            this.pub.hset(roomId, key, value, resolve);
+            this.pub.hset(key, field, value, resolve);
         });
     }
 
-    public async hget(roomId: string, key: string) {
-        return await this.hgetAsync(roomId, key);
-    }
-
-    public async hdel(roomId: string, key: string) {
+    public async hincrby(key: string, field: string, value: number) {
         return new Promise((resolve) => {
-            this.pub.hdel(roomId, key, resolve);
+            this.pub.hincrby(key, field, value, resolve);
         });
     }
 
-    public async hlen(roomId: string): Promise<number> {
-        return await this.hlenAsync(roomId);
+    public async hget(key: string, field: string) {
+        return await this.hgetAsync(key, field);
+    }
+
+    public async hgetall(key: string) {
+        return new Promise<{ [key: string]: string }>((resolve, reject) => {
+            this.pub.hgetall(key, (err, values) => {
+              if (err) { return reject(err); }
+              resolve(values);
+            });
+        });
+    }
+
+    public async hdel(key: string, field: string) {
+        return new Promise((resolve, reject) => {
+            this.pub.hdel(key, field, (err, ok) => {
+              if (err) { return reject(err); }
+              resolve(ok);
+            });
+        });
+    }
+
+    public async hlen(key: string): Promise<number> {
+        return await this.hlenAsync(key);
     }
 
     public async incr(key: string): Promise<number> {

--- a/src/rooms/RelayRoom.ts
+++ b/src/rooms/RelayRoom.ts
@@ -1,6 +1,6 @@
-import { Context, defineTypes, MapSchema, Schema, type } from '@colyseus/schema';
+import { Context, defineTypes, MapSchema, Schema } from '@colyseus/schema';
 
-import { Client } from '..';
+import { Client } from '../Protocol';
 import { Room } from '../Room';
 
 /**

--- a/src/transport/WebSocketTransport.ts
+++ b/src/transport/WebSocketTransport.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import querystring from 'querystring';
 import url from 'url';
 import WebSocket from 'ws';
 
@@ -6,7 +7,6 @@ import { Client, Protocol } from '..';
 import * as matchMaker from '../MatchMaker';
 
 import { send } from '../Protocol';
-import { parseQueryString } from '../Utils';
 import { ServerOptions } from './../Server';
 import { Transport } from './Transport';
 
@@ -93,7 +93,7 @@ export class WebSocketTransport extends Transport {
     const upgradeReq = req || client.upgradeReq;
     const parsedURL = url.parse(upgradeReq.url);
 
-    const { sessionId } = parseQueryString(parsedURL.query);
+    const sessionId = querystring.parse(parsedURL.query).sessionId as string;
     const processAndRoomId = parsedURL.pathname.match(/\/[a-zA-Z0-9_\-]+\/([a-zA-Z0-9_\-]+)$/);
     const roomId = processAndRoomId && processAndRoomId[1];
 

--- a/test/IPCTest.ts
+++ b/test/IPCTest.ts
@@ -1,0 +1,45 @@
+import assert from "assert";
+
+import { PRESENCE_IMPLEMENTATIONS } from "./utils";
+import { subscribeIPC, requestFromIPC } from "../src/IPC";
+
+describe("Inter-process Communication", () => {
+  for (let i = 0; i < PRESENCE_IMPLEMENTATIONS.length; i++) {
+    const presence = PRESENCE_IMPLEMENTATIONS[i];
+
+    describe(`Using presence: ${presence.constructor.name}`, () => {
+
+      it("#subscribeIPC / #publishIPC", async () => {
+        await subscribeIPC(presence, "process-one", "channel", (method, args) => {
+          assert.equal("methodName", method);
+          assert.deepEqual(["one", 2, { boolean: true }], args);
+          return new Promise((resolve) => {
+            setTimeout(() => resolve(["two", 3, { boolean: true }]), 100);
+          });
+        });
+
+        await assert.doesNotReject(async () => {
+          const response = await requestFromIPC(presence, "channel", "methodName", ["one", 2, { boolean: true }]);
+          assert.deepEqual(["two", 3, { boolean: true }], response);
+        });
+
+      });
+
+      it("#publishIPC should allow 'undefined' methodName", async () => {
+        const channel = 'test-channel';
+
+        subscribeIPC(presence, "public-ipc-test", channel, (method, args) => {
+          assert.equal(undefined, method);
+          assert.deepEqual([true], args);
+          return "hello!"
+        });
+
+        await assert.doesNotReject(async () => {
+          const response = await requestFromIPC(presence, channel, undefined, [true]);
+          assert.equal("hello!", response);
+        });
+      });
+
+    });
+  }
+});

--- a/test/ServerTest.ts
+++ b/test/ServerTest.ts
@@ -6,22 +6,23 @@ import { DummyRoom } from "./utils";
 
 describe("Server", () => {
 
+  const server = new Server();
+
+  // bind & unbind server
+  before(async () => new Promise((resolve) => {
+    // setup matchmaker
+    matchMaker.setup(undefined, undefined, 'dummyProcessId')
+
+    // define a room
+    server.define("roomName", DummyRoom);
+
+    // listen for testing
+    server.listen(8567, undefined, undefined, resolve);
+  }));
+
+  after(() => server.transport.shutdown());
+
   describe("matchmaking routes", () => {
-    const server = new Server();
-
-    // bind & unbind server
-    before(async () => new Promise((resolve) => {
-      // setup matchmaker
-      matchMaker.setup(undefined, undefined, 'dummyProcessId')
-
-      // define a room
-      server.define("roomName", DummyRoom);
-
-      // listen for testing
-      server.listen(8567, undefined, undefined, resolve);
-    }));
-
-    after(() => server.transport.shutdown());
 
     it("should respond to GET /matchmake/ to retrieve list of rooms", async () => {
       const response = await httpClient.get("http://localhost:8567/matchmake/");
@@ -40,6 +41,13 @@ describe("Server", () => {
       assert.equal(data.room.name, 'roomName');
     });
 
+
+  });
+
+  describe("API", () => {
+    it("server.define() should throw error if argument is invalid", () => {
+      assert.throws(() => server.define("dummy", undefined));
+    });
   });
 
 });


### PR DESCRIPTION
> I'm going to test this on production soon. Leaving this as a draft until it actually works for my use-case!

This PR includes a few housekeeping changes and the ability for any process to ask for other processes to create the room, whenever it's requested.

- When the process is initialized Presence receives `roomcaches[processId] = 0`
- Whenever a room is created, Presence is updated to `roomcaches[processId]++`
- Whenever a room is removed, Presence is updated to `roomcaches[processId]--`
- During shutdown, Presence is updated to `delete roomcaches[processId]`

When a "create room" request is received on any process, the `roomcaches` is queried, and the process with the least amount of rooms will be used to create the room, via inter-process communication (`IPC.ts`)

The same applies when using `matchMaker.createRoom()` from the backend.

## Coming soon?

I believe this approach can evolve to support having multiple machines with a fixed ENDPOINT for each of them and having a regular load balancer behind all the machines. So when requesting to matchmake, the server can respond with the ENDPOINT + roomId, and the client could then connect directly to that endpoint, instead of relying on a single endpoint, as it works right now with the proxy.