### PR TITLE
Updates discovery to allow for Environment Variable overrides

### DIFF
--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -5,13 +5,14 @@ const NODES_SET = 'colyseus:nodes';
 const DISCOVERY_CHANNEL = 'colyseus:nodes:discovery';
 
 export interface Node {
-    port: number;
-    processId: string;
+  port: number;
+  processId: string;
 }
 
 async function getNodeAddress(node: Node) {
-  const ipv4 = await ip.v4();
-  return `${node.processId}/${ipv4}:${node.port}`;
+  const host = process.env.SELF_HOSTNAME || await ip.v4();
+  const port = process.end.SELF_PORT || node.port;
+  return `${node.processId}/${host}:${port}`;
 }
 
 export async function registerNode(presence: Presence, node: Node) {


### PR DESCRIPTION
By allowing environment variables to override the ip address and port
number used in the discovery api we can support in cluster routing (i.e.
nodes that do not have access to the external net).

An example of this would be routing to Game Servers contained behind a
kubernetes service
(https://kubernetes.io/docs/concepts/services-networking/service/).
Services by default do not have an external IP address assigned to them:
only an internal cluster IP.

When creating our deployments we can specify OVERRIDE_IP_ADDRESS and
OVERRIDE_PORT environment
variables.
These will allow internal cluster routing to work with the
existing proxy system.