### PR TITLE
WIP: SQL support driver based on Sequelize ORM

### DIFF
--- a/src/matchmaker/drivers/SequelizeDriver/Query.ts
+++ b/src/matchmaker/drivers/SequelizeDriver/Query.ts
@@ -1,0 +1,43 @@
+import { SortOptions } from '../../RegisteredHandler';
+import { QueryHelpers } from '../Driver';
+import { Model, Filterable, Order, OrderItem } from 'sequelize';
+import { RoomCache } from './RoomCache';
+
+const DESC_RE = /^$(-1|desc|descending)/i
+
+export class Query<T> implements QueryHelpers<T> {
+  private conditions: Filterable<Model['_attributes']>['where'];
+  private order: Order;
+
+  constructor(conditions: any) {
+    this.conditions = conditions;
+  }
+
+  public sort(options: SortOptions) {
+    const fields = Object.entries(options);
+
+    if (fields) {
+      const order: Order = [];
+
+      for (let [field, direction] of Object.entries(options)) {
+        if (DESC_RE.test(String(direction))) {
+          order.push([field, 'DESC']);
+        } else {
+          order.push([field, 'ASC']);
+        }
+      }
+
+      this.order = order;
+    }
+
+    return this;
+  }
+
+  public async then(resolve: any, reject: (reason?: any) => void) {
+    return RoomCache.findOne({
+      where: this.conditions,
+      order: this.order,
+      raw: true,
+    }).then(resolve, reject) as any;
+  }
+}

--- a/src/matchmaker/drivers/SequelizeDriver/RoomCache.ts
+++ b/src/matchmaker/drivers/SequelizeDriver/RoomCache.ts
@@ -1,0 +1,161 @@
+import { Model, ModelAttributes, DataTypes, Optional } from 'sequelize';
+import { ulid } from 'ulid';
+
+export interface Dictionary<T> {
+  [key: string]: T | undefined;
+}
+
+export interface RoomCacheAttributes {
+  id: string;
+  uuid: string;
+  clients: number;
+  maxClients: number;
+  metadata: Dictionary<unknown> | null;
+  locked: boolean;
+  private: boolean;
+  unlisted: boolean;
+  name: string;
+  processId: string;
+  roomId: string;
+}
+
+export interface RoomCacheCreationAttributes
+  extends Optional<RoomCacheAttributes, 'id' | 'uuid'> {}
+
+interface UpdateOperation {
+  $set?: RoomCacheCreationAttributes;
+  $inc?: RoomCacheCreationAttributes;
+}
+
+export class RoomCache
+  extends Model<RoomCacheAttributes, RoomCacheCreationAttributes>
+  implements RoomCacheAttributes {
+  public id!: string;
+  public uuid!: string;
+  public clients!: number;
+  public maxClients!: number;
+  public metadata!: Dictionary<string> | null;
+  public locked!: boolean;
+  public private!: boolean;
+  public unlisted!: boolean;
+  public name!: string;
+  public processId!: string;
+  public roomId!: string;
+
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+
+  public toJSON() {
+    return {
+      clients: this.clients,
+      createdAt: this.createdAt,
+      maxClients: this.maxClients,
+      metadata: this.metadata,
+      name: this.name,
+      processId: this.processId,
+      roomId: this.roomId,
+    };
+  }
+
+  public async updateOne(operations: UpdateOperation) {
+    let changes = 0;
+
+    if (operations.$set) {
+      for (const [field, value] of Object.entries(operations.$set)) {
+        this[field as keyof this] = value;
+        changes += 1;
+      }
+    }
+
+    if (operations.$inc) {
+      for (const [field, value] of Object.entries(operations.$inc)) {
+        this[field as keyof this] += value;
+        changes += 1;
+      }
+    }
+
+    if (changes) {
+      await this.save();
+    }
+
+    return this;
+  }
+
+  public async remove() {
+    if (!this.isNewRecord) {
+      await this.destroy();
+    }
+  }
+}
+
+export const RoomCacacheSchema: ModelAttributes<
+  RoomCache,
+  RoomCache['_attributes']
+> = {
+  id: {
+    type: DataTypes.BIGINT.UNSIGNED,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  uuid: {
+    type: DataTypes.CHAR(26).BINARY,
+    defaultValue() {
+      return ulid().toLowerCase();
+    },
+    allowNull: false,
+    unique: true,
+  },
+  name: {
+    allowNull: false,
+    type: DataTypes.STRING,
+  },
+  processId: {
+    allowNull: false,
+    type: DataTypes.STRING,
+  },
+  roomId: {
+    allowNull: false,
+    type: DataTypes.STRING,
+  },
+  clients: {
+    allowNull: true,
+    type: DataTypes.INTEGER.UNSIGNED,
+    defaultValue: 0,
+  },
+  maxClients: {
+    allowNull: true,
+    type: DataTypes.INTEGER,
+    defaultValue: null,
+    get(): number {
+      const rawValue = this.getDataValue('maxClients');
+      return rawValue === null ? Infinity : rawValue;
+    },
+    set(value: number) {
+      this.setDataValue(
+        'maxClients',
+        value === Infinity || value < 0 ? null : value
+      );
+    },
+  },
+  metadata: {
+    allowNull: true,
+    type: DataTypes.JSON,
+  },
+  locked: {
+    allowNull: true,
+    defaultValue: false,
+    type: DataTypes.BOOLEAN,
+  },
+  private: {
+    allowNull: true,
+    defaultValue: false,
+    type: DataTypes.BOOLEAN,
+  },
+  unlisted: {
+    allowNull: true,
+    defaultValue: false,
+    type: DataTypes.BOOLEAN,
+    comment:
+      'Used for default LobbyRoom (prevent from showing up on room listing)',
+  },
+};

--- a/src/matchmaker/drivers/SequelizeDriver/RoomCache.ts
+++ b/src/matchmaker/drivers/SequelizeDriver/RoomCache.ts
@@ -88,7 +88,7 @@ export class RoomCache
   }
 }
 
-export const RoomCacacheSchema: ModelAttributes<
+export const RoomCacheSchema: ModelAttributes<
   RoomCache,
   RoomCache['_attributes']
 > = {

--- a/src/matchmaker/drivers/SequelizeDriver/index.ts
+++ b/src/matchmaker/drivers/SequelizeDriver/index.ts
@@ -1,6 +1,6 @@
 import { MatchMakerDriver, QueryHelpers, RoomListingData } from '../Driver';
 import { Sequelize, Options, Filterable, SyncOptions } from 'sequelize';
-import { RoomCache, RoomCacacheSchema } from './RoomCache';
+import { RoomCache, RoomCacheSchema } from './RoomCache';
 import { Query } from './Query';
 
 export class SequelizeDriver<TRecord extends {} = any, TResult = unknown[]>
@@ -10,7 +10,7 @@ export class SequelizeDriver<TRecord extends {} = any, TResult = unknown[]>
   public constructor(uri: string = 'sqlite::memory:', options?: Options) {
     this.connection = new Sequelize(uri, options);
 
-    RoomCache.init(RoomCacacheSchema, {
+    RoomCache.init(RoomCacheSchema, {
       sequelize: this.connection,
       modelName: 'RoomCache',
       tableName: 'room_caches',

--- a/src/matchmaker/drivers/SequelizeDriver/index.ts
+++ b/src/matchmaker/drivers/SequelizeDriver/index.ts
@@ -1,0 +1,48 @@
+import { MatchMakerDriver, QueryHelpers, RoomListingData } from '../Driver';
+import { Sequelize, Options, Filterable, SyncOptions } from 'sequelize';
+import { RoomCache, RoomCacacheSchema } from './RoomCache';
+import { Query } from './Query';
+
+export class SequelizeDriver<TRecord extends {} = any, TResult = unknown[]>
+  implements MatchMakerDriver {
+  public readonly connection: Sequelize;
+
+  public constructor(uri: string = 'sqlite::memory:', options?: Options) {
+    this.connection = new Sequelize(uri, options);
+
+    RoomCache.init(RoomCacacheSchema, {
+      sequelize: this.connection,
+      modelName: 'RoomCache',
+      tableName: 'room_caches',
+      indexes: [{ fields: ['name', 'locked'] }, { fields: ['locked'] }],
+      underscored: true,
+    });
+  }
+
+  public createInstance(initialValues: any = {}) {
+    return (new RoomCache(initialValues) as any) as RoomListingData;
+  }
+
+  public async find(where?: Filterable<RoomCache['_attributes']>['where']) {
+    const result = await RoomCache.findAll({
+      attributes: [
+        'clients',
+        'createdAt',
+        'locked',
+        'maxClients',
+        'metadata',
+        'name',
+        'roomId',
+      ],
+      where,
+    });
+
+    return (result as any) as RoomListingData[];
+  }
+
+  public findOne(conditions: any) {
+    return (new Query<RoomListingData>(
+      conditions
+    ) as any) as QueryHelpers<RoomListingData>;
+  }
+}


### PR DESCRIPTION
Good evening, everyone!
This is early preview for SQL driver, it was tested with MySQL 8.0. 

Any proposals and improvements are welcome ;) 

**Packages required:** 

```
sequelize: ^6.5.0
ulid: ^2.3.0
```

**MySQL table dump:**

```sql
CREATE TABLE `room_caches` (
  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
  `uuid` char(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
  `name` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
  `process_id` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
  `room_id` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
  `clients` int unsigned DEFAULT '0',
  `max_clients` int DEFAULT NULL,
  `metadata` json DEFAULT NULL,
  `locked` tinyint(1) DEFAULT '0',
  `private` tinyint(1) DEFAULT '0',
  `unlisted` tinyint(1) DEFAULT '0' COMMENT 'Used for default LobbyRoom (prevent from showing up on room listing)',
  `created_at` datetime NOT NULL,
  `updated_at` datetime NOT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `uuid` (`uuid`),
  KEY `room_caches_name_locked` (`name`,`locked`),
  KEY `room_caches_locked` (`locked`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
```

