### PR TITLE
Allow specifying roomId during room creation

### DIFF
--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -345,8 +345,8 @@ export function gracefullyShutdown(): Promise<any> {
 /**
  * Reserve a seat for a client in a room
  */
-export async function reserveSeatFor(room: RoomListingData, options: any) {
-  const sessionId: string = generateId();
+export async function reserveSeatFor(room: RoomListingData, options: any, sessionId?: string) {
+  sessionId = sessionId || generateId();
 
   debugMatchMaking(
     'reserving seat. sessionId: \'%s\', roomId: \'%s\', processId: \'%s\'',


### PR DESCRIPTION
The matchmaker currently generates the `roomId` for every created room. In combination with a separate matchmaker, it can be required to be able to specify the `roomId` in advance.

This PR adds a new optional parameter to the `createRoom` method, which allows to specify a room id. If the parameter is not set, everything behaves as before.

Once there are more parameters, it might make sense to have a separate options object, e.g.:
```js
export async function createRoom(roomName: string, clientOptions: ClientOptions, { roomId } : {roomId?: string}): Promise<RoomListingData> {
}
```
