### PR TITLE
Add esm folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn.lock
 
 .nyc_output
 coverage
+esm


### PR DESCRIPTION
The build artefacts are currently not contained in the gitignore, causing to show a lot of changes. Let me know if I missed something.