### PR TITLE
#428 default _autoDisposeTimeout

### DIFF
--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -106,6 +106,8 @@ export abstract class Room<State= any, Metadata= any> {
     });
 
     this.setPatchRate(this.patchRate);
+    // set default _autoDisposeTimeout
+    this.resetAutoDisposeTimeout(this.seatReservationTime);
   }
 
   // Optional abstract methods


### PR DESCRIPTION
This will set a default auto-dispose timeout upon room creation.
Reference issue: #428 