### PR TITLE
#437 Return all rooms when roomName is undefined

### DIFF
--- a/bundles/colyseus/test/IntegrationTest.ts
+++ b/bundles/colyseus/test/IntegrationTest.ts
@@ -886,6 +886,29 @@ describe("Integration", () => {
 
           })
 
+          describe("Matchmaker queries", () => {
+            const createDummyRooms = async () => {
+              matchMaker.defineRoomType('allroomstest', class _ extends Room {});
+              matchMaker.defineRoomType('allroomstest2', class _ extends Room {});
+              await matchMaker.create("allroomstest");
+              await matchMaker.create("allroomstest2");
+            }
+            it("client.getAvailableRooms() should recieve all rooms when roomName is undefined", async () => {
+              await createDummyRooms();
+              const rooms = await client.getAvailableRooms(undefined);
+              assert.strictEqual(2, rooms.length);
+            });
+            it("client.getAvailableRooms() should recieve the room when roomName is given", async () => {
+              await createDummyRooms();
+              const rooms = await client.getAvailableRooms("allroomstest");
+              assert.strictEqual("allroomstest", rooms[0]["name"]);
+            });
+            it("client.getAvailableRooms() should recieve empty list if no room exists for the given roomName", async () => {
+              await createDummyRooms();
+              const rooms = await client.getAvailableRooms("incorrectRoomName");
+              assert.strictEqual(0, rooms.length);
+            });
+          })
         });
 
         describe("Error handling", () => {

--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -272,7 +272,7 @@ export class Server {
 
     } else if (req.method === 'GET') {
       const matchedParams = req.url.match(this.allowedRoomNameChars);
-      const roomName = matchedParams[matchedParams.length - 1];
+      const roomName = matchedParams.length > 1 ? matchedParams[matchedParams.length - 1] : "";
 
       headers['Content-Type'] = 'application/json';
       res.writeHead(200, headers);

--- a/packages/core/src/matchmaker/controller.ts
+++ b/packages/core/src/matchmaker/controller.ts
@@ -18,9 +18,10 @@ export function getAvailableRooms(roomName: string) {
     const conditions: any = {
         locked: false,
         private: false,
-        name: roomName,
     };
-
+    if (roomName) {
+        conditions["name"] = roomName;
+    }
     return matchMaker.query(conditions);
 }
 

--- a/packages/transport/uwebsockets-transport/src/uWebSocketsTransport.ts
+++ b/packages/transport/uwebsockets-transport/src/uWebSocketsTransport.ts
@@ -246,7 +246,7 @@ export class uWebSocketsTransport extends Transport {
 
             const url = req.getUrl();
             const matchedParams = url.match(allowedRoomNameChars);
-            const roomName = matchedParams[matchedParams.length - 1];
+            const roomName = matchedParams.length > 1 ? matchedParams[matchedParams.length - 1] : "";
 
             try {
                 const response = await matchMaker.controller.getAvailableRooms(roomName || '')


### PR DESCRIPTION
When `roomName ` is not provided, `roomName` has been taken as `matchmake` from the request URI. This PR is fixes #437 
