### PR TITLE
use "ioredis" instead of "redis" for Cluster support

### DIFF
--- a/bundles/colyseus/test/IntegrationTest.ts
+++ b/bundles/colyseus/test/IntegrationTest.ts
@@ -29,6 +29,7 @@ describe("Integration", () => {
           presence = new PRESENCE_IMPLEMENTATIONS[i]();
 
           server = new Server({
+            gracefullyShutdown: false,
             presence,
             driver,
             // transport: new uWebSocketsTransport(),

--- a/bundles/colyseus/test/PresenceTest.ts
+++ b/bundles/colyseus/test/PresenceTest.ts
@@ -1,12 +1,15 @@
 import assert from "assert";
+import { Presence } from "../src";
 import { timeout, PRESENCE_IMPLEMENTATIONS } from "./utils";
 
 describe("Presence", () => {
 
   for (let i = 0; i < PRESENCE_IMPLEMENTATIONS.length; i++) {
-    const presence = new PRESENCE_IMPLEMENTATIONS[i]();
+    let presence: Presence;
 
-    describe((presence as any).constructor.name, () => {
+    describe((PRESENCE_IMPLEMENTATIONS[i]).constructor.name, () => {
+      beforeEach(() => presence = new PRESENCE_IMPLEMENTATIONS[i]())
+      afterEach(() => presence.shutdown());
 
       it("subscribe", (done) => {
         let i = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
 				"fossil-delta": "^1.0.1",
 				"html-webpack-plugin": "^3.2.0",
 				"internal-ip": "^4.3.0",
+				"ioredis": "^4.27.9",
 				"material-ui": "^0.20.0",
 				"mongoose": "^5.11.3",
 				"nanoid": "^2.0.0",
@@ -47,7 +48,6 @@
 				"react-json-edit": "^0.3.1",
 				"react-json-view": "^1.16.1",
 				"react-router-dom": "^4.2.2",
-				"redis": "^2.8.0",
 				"style-loader": "^0.20.3",
 				"superagent": "^3.8.2",
 				"ts-loader": "^4.2.0",
@@ -70,6 +70,7 @@
 				"@types/debug": "^0.0.31",
 				"@types/express": "^4.16.1",
 				"@types/fossil-delta": "^1.0.0",
+				"@types/ioredis": "^4.27.3",
 				"@types/jest": "^26.0.24",
 				"@types/koa": "^2.0.49",
 				"@types/mocha": "^5.2.7",
@@ -4232,6 +4233,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/ioredis": {
+			"version": "4.27.3",
+			"resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.27.3.tgz",
+			"integrity": "sha512-XKt0Jh+UTleEPm6RoumukUOIKl14eQPQ+qhZgtAV9LpWH1ISmyI2BLyXreKO8WAF3tYgPQTcUmajbdrHs/esaQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.3",
 			"dev": true,
@@ -5189,6 +5199,7 @@
 		},
 		"node_modules/arrify": {
 			"version": "1.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6598,6 +6609,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/cluster-key-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+			"integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/cmd-shim": {
 			"version": "4.1.0",
 			"dev": true,
@@ -6740,6 +6759,7 @@
 		},
 		"node_modules/colyseus.js": {
 			"version": "0.14.13",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@colyseus/schema": "^1.0.22",
@@ -7703,6 +7723,7 @@
 		},
 		"node_modules/diff": {
 			"version": "3.5.0",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
@@ -7866,10 +7887,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/double-ended-queue": {
-			"version": "2.1.0-0",
-			"license": "MIT"
 		},
 		"node_modules/duplexer": {
 			"version": "0.1.2",
@@ -10418,6 +10435,7 @@
 		},
 		"node_modules/httpie": {
 			"version": "2.0.0-next.13",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -10809,6 +10827,50 @@
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.0.0"
+			}
+		},
+		"node_modules/ioredis": {
+			"version": "4.27.9",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.9.tgz",
+			"integrity": "sha512-hAwrx9F+OQ0uIvaJefuS3UTqW+ByOLyLIV+j0EH8ClNVxvFyH9Vmb08hCL4yje6mDYT5zMquShhypkd50RRzkg==",
+			"dependencies": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ioredis"
+			}
+		},
+		"node_modules/ioredis/node_modules/p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/ioredis/node_modules/redis-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+			"integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+			"dependencies": {
+				"redis-errors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/ip": {
@@ -13894,6 +13956,16 @@
 			"version": "4.1.1",
 			"license": "MIT"
 		},
+		"node_modules/lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+		},
 		"node_modules/lodash.flow": {
 			"version": "3.5.0",
 			"license": "MIT"
@@ -13902,6 +13974,11 @@
 			"version": "4.4.2",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
 		},
 		"node_modules/lodash.ismatch": {
 			"version": "4.4.0",
@@ -14001,6 +14078,7 @@
 		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/make-fetch-happen": {
@@ -17736,27 +17814,16 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/redis": {
-			"version": "2.8.0",
-			"license": "MIT",
-			"dependencies": {
-				"double-ended-queue": "^2.1.0-0",
-				"redis-commands": "^1.2.0",
-				"redis-parser": "^2.6.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/redis-commands": {
 			"version": "1.7.0",
 			"license": "MIT"
 		},
-		"node_modules/redis-parser": {
-			"version": "2.6.0",
-			"license": "MIT",
+		"node_modules/redis-errors": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+			"integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=4"
 			}
 		},
 		"node_modules/reduce-css-calc": {
@@ -18986,6 +19053,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/standard-as-callback": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+		},
 		"node_modules/static-extend": {
 			"version": "0.1.2",
 			"license": "MIT",
@@ -20032,6 +20104,7 @@
 		},
 		"node_modules/ts-node": {
 			"version": "7.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"arrify": "^1.0.0",
@@ -20126,6 +20199,7 @@
 		},
 		"node_modules/ts-node/node_modules/mkdirp": {
 			"version": "0.5.5",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5"
@@ -22548,9 +22622,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-			"integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+			"integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
 			"engines": {
 				"node": ">=8.3.0"
 			},
@@ -22740,6 +22814,7 @@
 		},
 		"node_modules/yn": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -22774,7 +22849,7 @@
 		},
 		"packages/core": {
 			"name": "@colyseus/core",
-			"version": "0.14.23",
+			"version": "0.14.24",
 			"license": "MIT",
 			"dependencies": {
 				"@colyseus/schema": "^1.0.15",
@@ -22833,7 +22908,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@colyseus/core": "^0.14.20",
-				"redis": "^2.8.0"
+				"ioredis": "^4.27.9"
 			}
 		},
 		"packages/drivers/redis-driver/node_modules/@colyseus/core": {
@@ -22872,19 +22947,11 @@
 			"version": "0.14.7",
 			"license": "MIT",
 			"dependencies": {
-				"blessed": "^0.1.81",
-				"colyseus.js": "^0.14.13",
-				"minimist": "^1.2.5",
-				"ts-node": "^7.0.1",
-				"typescript": "^4.3.5",
-				"ws": "^7.4.5"
+				"typescript": "^4.3.5"
 			},
 			"bin": {
 				"colyseus-loadtest": "bin.js",
 				"colyseus-loadtest-esm": "bin.mjs"
-			},
-			"devDependencies": {
-				"@types/blessed": "^0.1.10"
 			}
 		},
 		"packages/loadtest/node_modules/typescript": {
@@ -22896,13 +22963,6 @@
 			},
 			"engines": {
 				"node": ">=4.2.0"
-			}
-		},
-		"packages/loadtest/node_modules/ws": {
-			"version": "6.2.2",
-			"license": "MIT",
-			"dependencies": {
-				"async-limiter": "~1.0.0"
 			}
 		},
 		"packages/monitor": {
@@ -22963,7 +23023,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@colyseus/core": "^0.14.20",
-				"redis": "^2.8.0"
+				"ioredis": "^4.27.9"
 			}
 		},
 		"packages/presence/redis-presence/node_modules/@colyseus/core": {
@@ -23073,7 +23133,7 @@
 		},
 		"packages/transport/uwebsockets-transport": {
 			"name": "@colyseus/uwebsockets-transport",
-			"version": "0.14.25",
+			"version": "0.14.26",
 			"license": "MIT",
 			"dependencies": {
 				"@colyseus/core": "^0.14.20",
@@ -23568,23 +23628,11 @@
 		"@colyseus/loadtest": {
 			"version": "file:packages/loadtest",
 			"requires": {
-				"@types/blessed": "^0.1.10",
-				"blessed": "^0.1.81",
-				"colyseus.js": "^0.14.13",
-				"minimist": "^1.2.5",
-				"ts-node": "^7.0.1",
-				"typescript": "^4.3.5",
-				"ws": "^7.4.5"
+				"typescript": "^4.3.5"
 			},
 			"dependencies": {
 				"typescript": {
 					"version": "3.9.10"
-				},
-				"ws": {
-					"version": "6.2.2",
-					"requires": {
-						"async-limiter": "~1.0.0"
-					}
 				}
 			}
 		},
@@ -23679,7 +23727,7 @@
 			"version": "file:packages/drivers/redis-driver",
 			"requires": {
 				"@colyseus/core": "^0.14.20",
-				"redis": "^2.8.0"
+				"ioredis": "^4.27.9"
 			},
 			"dependencies": {
 				"@colyseus/core": {
@@ -23700,7 +23748,7 @@
 			"version": "file:packages/presence/redis-presence",
 			"requires": {
 				"@colyseus/core": "^0.14.20",
-				"redis": "^2.8.0"
+				"ioredis": "^4.27.9"
 			},
 			"dependencies": {
 				"@colyseus/core": {
@@ -26239,6 +26287,15 @@
 			"version": "1.8.0",
 			"dev": true
 		},
+		"@types/ioredis": {
+			"version": "4.27.3",
+			"resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.27.3.tgz",
+			"integrity": "sha512-XKt0Jh+UTleEPm6RoumukUOIKl14eQPQ+qhZgtAV9LpWH1ISmyI2BLyXreKO8WAF3tYgPQTcUmajbdrHs/esaQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.3",
 			"dev": true
@@ -26930,7 +26987,8 @@
 			"version": "0.3.2"
 		},
 		"arrify": {
-			"version": "1.0.1"
+			"version": "1.0.1",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6"
@@ -27892,6 +27950,11 @@
 				}
 			}
 		},
+		"cluster-key-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+			"integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+		},
 		"cmd-shim": {
 			"version": "4.1.0",
 			"dev": true,
@@ -28034,7 +28097,7 @@
 					"version": "file:packages/presence/redis-presence",
 					"requires": {
 						"@colyseus/core": "^0.14.20",
-						"redis": "^2.8.0"
+						"ioredis": "^4.27.9"
 					},
 					"dependencies": {
 						"@colyseus/core": {
@@ -28078,6 +28141,7 @@
 		},
 		"colyseus.js": {
 			"version": "0.14.13",
+			"dev": true,
 			"requires": {
 				"@colyseus/schema": "^1.0.22",
 				"httpie": "^2.0.0-next.13",
@@ -28754,7 +28818,8 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "3.5.0"
+			"version": "3.5.0",
+			"dev": true
 		},
 		"diff-sequences": {
 			"version": "27.0.6",
@@ -28857,9 +28922,6 @@
 		},
 		"dotenv": {
 			"version": "8.6.0"
-		},
-		"double-ended-queue": {
-			"version": "2.1.0-0"
 		},
 		"duplexer": {
 			"version": "0.1.2",
@@ -30587,7 +30649,8 @@
 			"version": "2.1.4"
 		},
 		"httpie": {
-			"version": "2.0.0-next.13"
+			"version": "2.0.0-next.13",
+			"dev": true
 		},
 		"https-browserify": {
 			"version": "1.0.0"
@@ -30838,6 +30901,39 @@
 			"version": "2.2.4",
 			"requires": {
 				"loose-envify": "^1.0.0"
+			}
+		},
+		"ioredis": {
+			"version": "4.27.9",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.9.tgz",
+			"integrity": "sha512-hAwrx9F+OQ0uIvaJefuS3UTqW+ByOLyLIV+j0EH8ClNVxvFyH9Vmb08hCL4yje6mDYT5zMquShhypkd50RRzkg==",
+			"requires": {
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.1",
+				"denque": "^1.1.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isarguments": "^3.1.0",
+				"p-map": "^2.1.0",
+				"redis-commands": "1.7.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			},
+			"dependencies": {
+				"p-map": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+				},
+				"redis-parser": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+					"integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+					"requires": {
+						"redis-errors": "^1.0.0"
+					}
+				}
 			}
 		},
 		"ip": {
@@ -32824,12 +32920,27 @@
 		"lodash.curry": {
 			"version": "4.1.1"
 		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+		},
 		"lodash.flow": {
 			"version": "3.5.0"
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"dev": true
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -32896,7 +33007,8 @@
 			}
 		},
 		"make-error": {
-			"version": "1.3.6"
+			"version": "1.3.6",
+			"dev": true
 		},
 		"make-fetch-happen": {
 			"version": "8.0.14",
@@ -35501,19 +35613,13 @@
 				"strip-indent": "^3.0.0"
 			}
 		},
-		"redis": {
-			"version": "2.8.0",
-			"requires": {
-				"double-ended-queue": "^2.1.0-0",
-				"redis-commands": "^1.2.0",
-				"redis-parser": "^2.6.0"
-			}
-		},
 		"redis-commands": {
 			"version": "1.7.0"
 		},
-		"redis-parser": {
-			"version": "2.6.0"
+		"redis-errors": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+			"integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
 		},
 		"reduce-css-calc": {
 			"version": "1.3.0",
@@ -36370,6 +36476,11 @@
 				}
 			}
 		},
+		"standard-as-callback": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"requires": {
@@ -37088,6 +37199,7 @@
 		},
 		"ts-node": {
 			"version": "7.0.1",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.0",
 				"buffer-from": "^1.1.0",
@@ -37101,6 +37213,7 @@
 			"dependencies": {
 				"mkdirp": {
 					"version": "0.5.5",
+					"dev": true,
 					"requires": {
 						"minimist": "^1.2.5"
 					}
@@ -38799,9 +38912,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-			"integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+			"integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
 			"requires": {}
 		},
 		"xml-name-validator": {
@@ -38915,7 +39028,8 @@
 			"dev": true
 		},
 		"yn": {
-			"version": "2.0.0"
+			"version": "2.0.0",
+			"dev": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/debug": "^0.0.31",
     "@types/express": "^4.16.1",
     "@types/fossil-delta": "^1.0.0",
+    "@types/ioredis": "^4.27.3",
     "@types/jest": "^26.0.24",
     "@types/koa": "^2.0.49",
     "@types/mocha": "^5.2.7",

--- a/packages/drivers/redis-driver/package.json
+++ b/packages/drivers/redis-driver/package.json
@@ -7,7 +7,7 @@
   "typings": "./build/index.d.ts",
   "dependencies": {
     "@colyseus/core": "^0.14.20",
-    "redis": "^2.8.0"
+    "ioredis": "^4.27.9"
   },
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/packages/drivers/redis-driver/src/RoomData.ts
+++ b/packages/drivers/redis-driver/src/RoomData.ts
@@ -1,5 +1,5 @@
 import { RoomListingData } from '@colyseus/core';
-import { RedisClient } from 'redis';
+import Redis from 'ioredis';
 
 export class RoomData implements RoomListingData {
   public clients: number = 0;
@@ -13,11 +13,11 @@ export class RoomData implements RoomListingData {
   public createdAt: Date;
   public unlisted: boolean = false;
 
-  #client: RedisClient;
+  #client: Redis.Redis;
 
   constructor(
     initialValues: any,
-    client: RedisClient
+    client: Redis.Redis
   ) {
     this.#client = client;
 
@@ -86,25 +86,11 @@ export class RoomData implements RoomListingData {
     }
   }
 
-  private hset(key: string, field: string, value: string) {
-    return new Promise((resolve, reject) => {
-      this.#client.hset(key, field, value, function (err, res) {
-        if (err) {
-          return reject(err);
-        }
-        resolve(res);
-      });
-    });
+  private async hset(key: string, field: string, value: string) {
+    return await this.#client.hset(key, field, value);
   }
 
-  private hdel(key: string, field: string) {
-    return new Promise((resolve, reject) => {
-      this.#client.hdel(key, field, function (err, res) {
-        if (err) {
-          return reject(err);
-        }
-        resolve(res);
-      });
-    });
+  private async hdel(key: string, field: string) {
+    return await this.#client.hdel(key, field);
   }
 }

--- a/packages/drivers/redis-driver/src/index.ts
+++ b/packages/drivers/redis-driver/src/index.ts
@@ -1,4 +1,4 @@
-import redis, { RedisClient, ClientOpts } from 'redis';
+import Redis from 'ioredis';
 import { promisify } from 'util';
 
 import {
@@ -12,12 +12,10 @@ import { Query } from './Query';
 import { RoomData } from './RoomData';
 
 export class RedisDriver implements MatchMakerDriver {
-  private readonly _client: RedisClient;
-  private readonly hgetall: (key: string) => Promise<{ [key: string]: string }>;
+  private readonly _client: Redis.Redis;
 
-  constructor(options?: ClientOpts, key: string = 'roomcaches') {
-    this._client = redis.createClient(options);
-    this.hgetall = promisify(this._client.hgetall).bind(this._client);
+  constructor(options?: Redis.RedisOptions, key: string = 'roomcaches') {
+    this._client = new Redis(options);
   }
 
   public createInstance(initialValues: any = {}) {
@@ -48,7 +46,7 @@ export class RedisDriver implements MatchMakerDriver {
   }
 
   public async getRooms() {
-    return Object.entries(await this.hgetall('roomcaches') ?? []).map(
+    return Object.entries(await this._client.hgetall('roomcaches') ?? []).map(
       ([, roomcache]) => new RoomData(JSON.parse(roomcache), this._client)
     );
   }

--- a/packages/example/src/DummyRoom.ts
+++ b/packages/example/src/DummyRoom.ts
@@ -53,20 +53,20 @@ export class DummyRoom extends Room<State> {
     this.state.lastMessage = `${ client.sessionId } joined.`;
   }
 
-  // async onLeave (client, consented) {
-  //   console.log("IS CONSENTED?", consented);
+  async onLeave (client, consented) {
+    console.log("IS CONSENTED?", consented);
 
-  //   try {
-  //     if (consented) throw new Error("just close!");
+    try {
+      if (consented) throw new Error("just close!");
 
-  //     await this.allowReconnection(client, 10);
-  //     console.log("CLIENT RECONNECTED");
+      await this.allowReconnection(client, 25);
+      console.log("CLIENT RECONNECTED");
 
-  //   } catch (e) {
-  //     this.state.lastMessage = `${client.sessionId} left.`;
-  //     console.log("ChatRoom:", client.sessionId, "left!");
-  //   }
-  // }
+    } catch (e) {
+      this.state.lastMessage = `${client.sessionId} left.`;
+      console.log("ChatRoom:", client.sessionId, "left!");
+    }
+  }
 
   onDispose () {
     console.log("Disposing ChatRoom...");

--- a/packages/presence/redis-presence/package.json
+++ b/packages/presence/redis-presence/package.json
@@ -7,7 +7,7 @@
   "typings": "./build/index.d.ts",
   "dependencies": {
     "@colyseus/core": "^0.14.20",
-    "redis": "^2.8.0"
+    "ioredis": "^4.27.9"
   },
   "author": "Endel Dreyer",
   "license": "MIT",


### PR DESCRIPTION
This PR replaces the `redis` package with `ioredis` for both `@colyseus/redis-presence` and `@colyseus/redis-driver`.