### PR TITLE
Allow calling colyseus.sdk.reconnect in unit testing

### DIFF
--- a/packages/testing/src/TestServer.ts
+++ b/packages/testing/src/TestServer.ts
@@ -9,6 +9,7 @@ export class ColyseusTestServer {
     join: Client['join'],
     create: Client['create'],
     joinById: Client['joinById'],
+    reconnect: Client['reconnect'],
   };
 
   public http: {
@@ -40,6 +41,7 @@ export class ColyseusTestServer {
       join: client.join.bind(client),
       create: client.create.bind(client),
       joinById: client.joinById.bind(client),
+      reconnect: client.reconnect.bind(client),
     };
   }
 


### PR DESCRIPTION
Hello.

I wanted to test reconnection using colyseus/testing. But [The manual](https://docs.colyseus.io/colyseus/tools/unit-testing/) only listed create and join methods, and the implementation was the same. I have added reconnect method binding in this PR. Please feel free to accept, comment or reject.

I have applied the exact same patch to the node_modules in my own project first and it worked. Then I patched the official repo's code (this PR). I wanted to test it by building and replacing colyseus/testing package with the locally-modified one, but it could not be loaded due to "default transport layer is not provided" error. Maybe one of the changes after the last released version?