### PR TITLE
Fix room.toJSON is not a function on 0.15

### DIFF
--- a/packages/core/src/matchmaker/driver/RoomData.ts
+++ b/packages/core/src/matchmaker/driver/RoomData.ts
@@ -70,4 +70,17 @@ export class RoomCache implements RoomListingData {
     spliceOne(this.$rooms, roomIndex);
     this.$rooms = null;
   }
+
+  public toJSON() {
+    return {
+      clients: this.clients,
+      createdAt: this.createdAt,
+      maxClients: this.maxClients,
+      metadata: this.metadata,
+      name: this.name,
+      publicAddress: this.publicAddress,
+      processId: this.processId,
+      roomId: this.roomId,
+    };
+  }
 }


### PR DESCRIPTION
Colyseus monitor references this but it was removed in a previous commit to the matchmaker driver, unsure if that was intentional.

Tests failed due to unrelated type issues so I couldn't check there, but monitor works fine.