### PR TITLE
Update mongoose to v6

### DIFF
--- a/packages/drivers/mongoose-driver/package.json
+++ b/packages/drivers/mongoose-driver/package.json
@@ -7,7 +7,7 @@
   "typings": "./build/index.d.ts",
   "dependencies": {
     "@colyseus/core": "^0.14.20",
-    "mongoose": "^5.11.3"
+    "mongoose": "^6.7.1"
   },
   "author": "Endel Dreyer",
   "license": "MIT",

--- a/packages/drivers/mongoose-driver/src/index.ts
+++ b/packages/drivers/mongoose-driver/src/index.ts
@@ -1,11 +1,13 @@
-import { IRoomListingData, MatchMakerDriver, QueryHelpers, RoomListingData, debugDriver } from '@colyseus/core';
-import mongoose, { Document, Schema } from 'mongoose';
+import type { RoomListingData, QueryHelpers, IRoomListingData, MatchMakerDriver } from '@colyseus/core';
+import { debugDriver } from '@colyseus/core';
+import type { Document } from 'mongoose';
+import Mongoose from 'mongoose';
 
-const RoomCacheSchema: Schema = new Schema({
+const RoomCacheSchema: Mongoose.Schema = new Mongoose.Schema({
   clients: { type: Number, default: 0 },
   locked: { type: Boolean, default: false },
   maxClients: { type: Number, default: Infinity },
-  metadata: Schema.Types.Mixed,
+  metadata: Mongoose.Schema.Types.Mixed,
   name: String,
   private: { type: Boolean, default: false },
   processId: String,
@@ -20,21 +22,15 @@ const RoomCacheSchema: Schema = new Schema({
 RoomCacheSchema.index({ name: 1, locked: -1 });
 RoomCacheSchema.index({ roomId: 1 });
 
-const RoomCache = mongoose.model<Document>('RoomCache', RoomCacheSchema);
+const RoomCache = Mongoose.model<Document>('RoomCache', RoomCacheSchema);
 
 export class MongooseDriver implements MatchMakerDriver {
-
   constructor(connectionURI?: string) {
-
-    if (mongoose.connection.readyState === mongoose.STATES.disconnected) {
+    if (Mongoose.connection.readyState === Mongoose.STATES.disconnected) {
       connectionURI = connectionURI || process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/colyseus';
 
-      mongoose.connect(connectionURI, {
+      Mongoose.connect(connectionURI, {
         autoIndex: true,
-        useCreateIndex: true,
-        useFindAndModify: true,
-        useNewUrlParser: true,
-        useUnifiedTopology: true,
       });
 
       debugDriver("🗄️ Connected to", connectionURI);
@@ -70,6 +66,6 @@ export class MongooseDriver implements MatchMakerDriver {
   }
 
   public async shutdown() {
-    await mongoose.disconnect();
+    await Mongoose.disconnect();
   }
 }


### PR DESCRIPTION
I've tested this locally & in a production environment, and things seem to be functioning normally. The only notable changes in the major bump of `mongoose`:

1. The MongoDB Driver used is now 4.0 (fixes #542 & allows connections to MongoDB Atlas)
2. The `connect` arguments are no longer necessary (see: https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options)

I've left the `version` the same for the package - not sure how you want to version this kind of change @endel - so feel free to modify as needed!