### PR TITLE
feat: make port optional in discovery node

### DIFF
--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -13,7 +13,7 @@ async function getNodeAddress(node: Node) {
   const host = process.env.SELF_HOSTNAME || await ip.v4();
   const port = process.env.SELF_PORT ?? node.port;
   const baseAddress = `${node.processId}/${host}`
-  const shouldPortBeAddedToAddress = !!port;
+  const shouldPortBeAddedToAddress: boolean = !!port;
   return shouldPortBeAddedToAddress ? `${baseAddress}:${port}` : baseAddress;
 }
 

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -12,8 +12,9 @@ export interface Node {
 async function getNodeAddress(node: Node) {
   const host = process.env.SELF_HOSTNAME || await ip.v4();
   const port = process.env.SELF_PORT ?? node.port;
+  const baseAddress = `${node.processId}/${host}`
   const shouldPortBeAddedToAddress = !!port;
-  return shouldPortBeAddedToAddress ? `${node.processId}/${host}:${port}` : `${node.processId}/${host}`;
+  return shouldPortBeAddedToAddress ? `${baseAddress}:${port}` : baseAddress;
 }
 
 export async function registerNode(presence: Presence, node: Node) {

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -12,8 +12,8 @@ export interface Node {
 async function getNodeAddress(node: Node) {
   const host = process.env.SELF_HOSTNAME || await ip.v4();
   const port = process.env.SELF_PORT ?? node.port;
-  const isPortSet = !!port;
-  return isPortSet ? `${node.processId}/${host}:${port}` : `${node.processId}/${host}`;
+  const shouldPortBeAddedToAddress = !!port;
+  return shouldPortBeAddedToAddress ? `${node.processId}/${host}:${port}` : `${node.processId}/${host}`;
 }
 
 export async function registerNode(presence: Presence, node: Node) {

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -12,7 +12,8 @@ export interface Node {
 async function getNodeAddress(node: Node) {
   const host = process.env.SELF_HOSTNAME || await ip.v4();
   const port = process.env.SELF_PORT ?? node.port;
-  return !!port ? `${node.processId}/${host}:${port}` : `${node.processId}/${host}`;
+  const isPortSet = !!port;
+  return isPortSet ? `${node.processId}/${host}:${port}` : `${node.processId}/${host}`;
 }
 
 export async function registerNode(presence: Presence, node: Node) {

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -12,9 +12,9 @@ export interface Node {
 async function getNodeAddress(node: Node) {
   const host = process.env.SELF_HOSTNAME || await ip.v4();
   const port = process.env.SELF_PORT ?? node.port;
-  const baseAddress = `${node.processId}/${host}`
-  const shouldPortBeAddedToAddress: boolean = !!port;
-  return shouldPortBeAddedToAddress ? `${baseAddress}:${port}` : baseAddress;
+  return (port) 
+    ? `${node.processId}/${host}:${port}`
+    : `${node.processId}/${host}`
 }
 
 export async function registerNode(presence: Presence, node: Node) {

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -11,8 +11,8 @@ export interface Node {
 
 async function getNodeAddress(node: Node) {
   const host = process.env.SELF_HOSTNAME || await ip.v4();
-  const port = process.env.SELF_PORT || node.port;
-  return `${node.processId}/${host}:${port}`;
+  const port = process.env.SELF_PORT ?? node.port;
+  return !!port ? `${node.processId}/${host}:${port}` : `${node.processId}/${host}`;
 }
 
 export async function registerNode(presence: Presence, node: Node) {


### PR DESCRIPTION
Sometimes you dont want to specify a port so https and wss use the default port when the proxy connects to the game server

in cloud env the container in which the server runs may uses internally a other port then under which the server is externally avaiable.
common is internally 8080 and externally 443/80

so this change would allow to set the SELF_PORT env variable to an empty string "" and it would not override it with node.port
only if SELF_PORT is undefined or null

Example
```ts
const port = undefined ?? 3000 // port=3000
const port = null ?? 3000 // port=3000
const port = '' ?? 3000 // port=''
const port = '443' ?? 3000 // port=443
```