### PR TITLE
feat: change time when greeting gets logged

### DIFF
--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -144,18 +144,18 @@ export class Server {
   public async listen(port: number, hostname?: string, backlog?: number, listeningListener?: Function) {
     this.port = port;
 
-    //
-    // Make sure matchmaker is ready before accepting connections
-    // (isDevMode: matchmaker may take extra milliseconds to restore the rooms)
-    //
-    await matchMaker.onReady;
-
     /**
      * Greetings!
      */
     if (this.greet) {
       console.log(greeting);
     }
+
+    //
+    // Make sure matchmaker is ready before accepting connections
+    // (isDevMode: matchmaker may take extra milliseconds to restore the rooms)
+    //
+    await matchMaker.onReady;
 
     return new Promise<void>((resolve, reject) => {
       this.transport.server?.on('error', (err) => reject(err));


### PR DESCRIPTION
Would it make sense to put the greeting at the start of listening?

or maybe add a log that its listning on the hostname:port at the end.

`Colyseus Server listening on ${hostname || 'localhost'}:${port}`