### PR TITLE
Change setPatchRate to accept milliseconds as null

### DIFF
--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -323,7 +323,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
     }
   }
 
-  public setPatchRate(milliseconds: number): void {
+  public setPatchRate(milliseconds: number | null): void {
     this.patchRate = milliseconds;
 
     // clear previous interval in case called setPatchRate more than once


### PR DESCRIPTION
In the documentation link provided (https://docs.colyseus.io/server/room/#broadcastpatch), you can disable PatchRate by using this.setPatchRate(null). 
However, I encountered an error while attempting to set setPatchRate to null. The error message states: 'Argument of type 'null' is not assignable to parameter of type 'number'.' To resolve this issue, I suggest modifying the code as follows to allow null as an argument as well.