### PR TITLE
[LobbyRoom] Update listed rooms on the client after rooms are marked as private

### DIFF
--- a/bundles/colyseus/test/rooms/LobbyRoomIntegration.test.ts
+++ b/bundles/colyseus/test/rooms/LobbyRoomIntegration.test.ts
@@ -1,12 +1,7 @@
 import assert from "assert";
-import sinon from "sinon";
 import * as Colyseus from "colyseus.js";
-
-import { matchMaker, Room, Client, Server, ErrorCode } from "../../src";
-import { DummyRoom, DRIVERS, timeout, Room3Clients, PRESENCE_IMPLEMENTATIONS, Room2Clients, Room2ClientsExplicitLock } from "./../utils";
-
-import { LobbyRoom } from "../../src";
-
+import { matchMaker, Server, LobbyRoom } from "../../src";
+import { DummyRoom, DRIVERS, timeout, PRESENCE_IMPLEMENTATIONS } from "./../utils";
 
 describe("LobbyRoom: Integration", () => {
   for (let i = 0; i < PRESENCE_IMPLEMENTATIONS.length; i++) {
@@ -34,7 +29,7 @@ describe("LobbyRoom: Integration", () => {
 
         beforeEach(async () => {
           // setup matchmaker
-          matchMaker.setup(presence, driver)
+          matchMaker.setup(presence, driver);
 
           // define a room
           matchMaker.defineRoomType("lobby", LobbyRoom);
@@ -43,7 +38,7 @@ describe("LobbyRoom: Integration", () => {
         });
 
         after(async () => await server.gracefullyShutdown(false));
-        afterEach(async () => await matchMaker.gracefullyShutdown())
+        afterEach(async () => await matchMaker.gracefullyShutdown());
 
         it("should receive full list of rooms when connecting.", async () => {
           await client.create('dummy_1');
@@ -56,8 +51,8 @@ describe("LobbyRoom: Integration", () => {
             onMessageCalled = true;
             assert.equal(2, rooms.length);
           });
-          lobby.onMessage("+", () => {});
-          lobby.onMessage("-", () => {});
+          lobby.onMessage("+", () => { });
+          lobby.onMessage("-", () => { });
 
           await timeout(50);
 
@@ -78,10 +73,10 @@ describe("LobbyRoom: Integration", () => {
           lobby.onMessage("+", ([roomId, data]) => {
             onAddCalled++;
             assert.equal("string", typeof (roomId));
-            assert.equal("dummy_1", data.name)
+            assert.equal("dummy_1", data.name);
           });
 
-          lobby.onMessage("-", () => {});
+          lobby.onMessage("-", () => { });
 
           await client.create('dummy_1');
           await client.create('dummy_1');
@@ -105,7 +100,7 @@ describe("LobbyRoom: Integration", () => {
             onMessageCalled = true;
             assert.equal(0, rooms.length);
           });
-          lobby.onMessage("+", () => {});
+          lobby.onMessage("+", () => { });
 
           await client.create('dummy_1');
           const dummy_1 = await client.create('dummy_1');
@@ -123,6 +118,57 @@ describe("LobbyRoom: Integration", () => {
           assert.equal(1, onRemoveCalled);
         });
 
+        it("should update rooms field when room marked as private", async () => {
+          const serverLobby = await matchMaker.createRoom('lobby', {});
+          const serverLobbyRoom = await matchMaker.getRoomById(serverLobby.roomId) as LobbyRoom;
+          const lobby = await client.join("lobby");
+
+          let allRooms: Colyseus.RoomAvailable[] = [];
+
+          lobby.onMessage("rooms", (rooms) => {
+            allRooms = rooms;
+          });
+
+          lobby.onMessage("+", ([roomId, room]) => {
+            const roomIndex = allRooms.findIndex((room) => room.roomId === roomId);
+            if (roomIndex !== -1) {
+              allRooms[roomIndex] = room;
+
+            } else {
+              allRooms.push(room);
+            }
+          });
+
+          lobby.onMessage("-", (roomId) => {
+            allRooms = allRooms.filter((room) => room.roomId !== roomId);
+          });
+
+          await client.create('dummy_1');
+          const dummy_1 = await client.create('dummy_1');
+          const dummyRoomId = dummy_1.roomId;
+
+          assert.equal(serverLobbyRoom.rooms.length, 2);
+          assert.equal(allRooms.length, 2);
+          assert.equal((await client.getAvailableRooms('dummy_1')).length, 2);
+
+          await matchMaker.remoteRoomCall(dummyRoomId, 'setPrivate');
+
+          await timeout(50);
+
+          assert.equal(serverLobbyRoom.rooms.length, 1);
+          assert.equal(allRooms.length, 1);
+          assert.equal((await client.getAvailableRooms('dummy_1')).length, 1);
+
+          await matchMaker.remoteRoomCall(dummyRoomId, 'setPrivate', [false]);
+
+          await timeout(50);
+
+          assert.equal(serverLobbyRoom.rooms.length, 2);
+          assert.equal(allRooms.length, 2);
+          assert.equal((await client.getAvailableRooms('dummy_1')).length, 2);
+
+          await lobby.leave();
+        });
       });
 
     }

--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -434,6 +434,8 @@ export async function handleCreateRoom(roomName: string, clientOptions: ClientOp
 
   room._events.on('lock', lockRoom.bind(this, room));
   room._events.on('unlock', unlockRoom.bind(this, room));
+  room._events.on('setPrivate', setPrivateRoom.bind(this, room));
+  room._events.on('setPublic', setPublicRoom.bind(this, room));
   room._events.on('join', onClientJoinRoom.bind(this, room));
   room._events.on('leave', onClientLeaveRoom.bind(this, room));
   room._events.once('dispose', disposeRoom.bind(this, roomName, room));
@@ -628,6 +630,14 @@ async function unlockRoom(room: Room) {
     // emit public event on registered handler
     handlers[room.roomName].emit('unlock', room);
   }
+}
+
+function setPrivateRoom(room: Room): void {
+  handlers[room.roomName].emit('setPrivate', room);
+}
+
+function setPublicRoom(room: Room): void {
+  handlers[room.roomName].emit('setPublic', room);
 }
 
 async function disposeRoom(roomName: string, room: Room) {

--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -375,11 +375,17 @@ export abstract class Room<State extends object= any, Metadata= any> {
   }
 
   public async setPrivate(bool: boolean = true) {
+    if (this.listing.private === bool) return;
+
     this.listing.private = bool;
 
     if (this._internalState === RoomInternalState.CREATED) {
       await this.listing.save();
     }
+
+    const evName = bool ? 'setPrivate' : 'setPublic';
+
+    this._events.emit(evName);
   }
 
   /**

--- a/packages/core/src/matchmaker/Lobby.ts
+++ b/packages/core/src/matchmaker/Lobby.ts
@@ -8,8 +8,12 @@ const LOBBY_CHANNEL = '$lobby';
 export function updateLobby(room: Room, removed: boolean = false) {
   const listing = room.listing;
 
-  if (!listing.unlisted && !listing.private) {
-    matchMaker.presence.publish(LOBBY_CHANNEL, `${listing.roomId},${removed ? 1 : 0}`);
+  if (listing.unlisted) return;
+
+  if (removed) {
+    matchMaker.presence.publish(LOBBY_CHANNEL, `${listing.roomId},1`);
+  } else if (!listing.private) {
+    matchMaker.presence.publish(LOBBY_CHANNEL, `${listing.roomId},0`);
   }
 }
 

--- a/packages/core/src/matchmaker/RegisteredHandler.ts
+++ b/packages/core/src/matchmaker/RegisteredHandler.ts
@@ -46,6 +46,9 @@ export class RegisteredHandler extends EventEmitter {
       }
     });
     this.on('dispose', (room) => updateLobby(room, true));
+    this.on('setPublic', (room) => updateLobby(room));
+    this.on('setPrivate', (room) => updateLobby(room, true));
+
     return this;
   }
 


### PR DESCRIPTION
Fix #617

Proposed solution:

There are 2 new room's events: `setPrivate` and `setPublic`.

I've also changed the `updateLobby` logic: the remove message always propagated even for private rooms.