### PR TITLE
[vuln] Bump msgpackr to 1.10.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "@gamestdio/timer": "^1.3.0",
     "@types/redis": "^2.8.12",
     "debug": "^4.3.4",
-    "msgpackr": "^1.9.1",
+    "msgpackr": "^1.10.1",
     "nanoid": "^2.0.0",
     "ws": "^7.4.5"
   },


### PR DESCRIPTION
msgpackr ≤1.10.0 is vulnerable to CVE-2023-52079, allowing DoS to any server or client that is allowed to decode arbitrary binary data to MessagePack. Exploited in the wild. Workaround is to disable the built-in extension 0x70.