### PR TITLE
Refactor how "static onAuth" is called internally

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/core",
-  "version": "0.15.22",
+  "version": "0.15.23-alpha.0",
   "description": "Multiplayer Framework for Node.js.",
   "input": "./src/index.ts",
   "main": "./build/index.js",

--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -120,7 +120,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
 
   // seat reservation & reconnection
   protected seatReservationTime: number = DEFAULT_SEAT_RESERVATION_TIME;
-  protected reservedSeats: { [sessionId: string]: any } = {};
+  protected reservedSeats: { [sessionId: string]: [any, any] } = {};
   protected reservedSeatTimeouts: { [sessionId: string]: NodeJS.Timer } = {};
 
   protected _reconnections: { [reconnectionToken: string]: [string, Deferred] } = {};
@@ -565,7 +565,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
     }
 
     // get seat reservation options and clear it
-    const options = this.reservedSeats[sessionId];
+    const [joinOptions, authData] = this.reservedSeats[sessionId];
 
     // share "after next patch queue" reference with every client.
     client._afterNextPatchQueue = this._afterNextPatchQueue;
@@ -581,12 +581,11 @@ export abstract class Room<State extends object= any, Metadata= any> {
 
     } else {
       try {
-        if (options['$auth']) {
-          client.auth = options['$auth'];
-          delete options['$auth'];
+        if (authData) {
+          client.auth = authData;
 
         } else if (this.onAuth !== Room.prototype.onAuth) {
-          client.auth = await this.onAuth(client, options, req);
+          client.auth = await this.onAuth(client, joinOptions, req);
 
           if (!client.auth) {
             throw new ServerError(ErrorCode.AUTH_FAILED, 'onAuth failed');
@@ -603,7 +602,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
         this.clients.push(client);
 
         if (this.onJoin) {
-          await this.onJoin(client, options, client.auth);
+          await this.onJoin(client, joinOptions, client.auth);
         }
 
         // emit 'join' to room handler (if not reconnecting)
@@ -692,7 +691,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
     const sessionId = previousClient.sessionId;
     const reconnectionToken = previousClient._reconnectionToken;
 
-    this._reserveSeat(sessionId, true, seconds, true);
+    this._reserveSeat(sessionId, true, previousClient.auth, seconds, true);
 
     // keep reconnection reference in case the user reconnects into this room.
     const reconnection = new Deferred<Client>();
@@ -807,7 +806,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
   private async _reserveSeat(
     sessionId: string,
     joinOptions: any = true,
-    authToken: string = undefined,
+    authData: any = undefined,
     seconds: number = this.seatReservationTime,
     allowReconnection: boolean = false,
     devModeReconnection?: boolean,
@@ -816,7 +815,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
       return false;
     }
 
-    this.reservedSeats[sessionId] = joinOptions;
+    this.reservedSeats[sessionId] = [joinOptions, authData];
 
     if (!allowReconnection) {
       await this._incrementClientCount();
@@ -829,18 +828,6 @@ export abstract class Room<State extends object= any, Metadata= any> {
 
       this.resetAutoDisposeTimeout(seconds);
     }
-
-
-    /**
-     * Check if static onAuth is implemented (default implementation is just to satisfy TypeScript)
-     * - On "reconnect" requests, the `roomClass` is undefined, as the "roomName" variable actually corresponds to the `roomId`.
-     */
-    if (authToken !== undefined && this.constructor['onAuth'] !== Room['onAuth']) {
-      const authHeader = req.headers['authorization'];
-      const authToken = (authHeader && authHeader.startsWith("Bearer ") && authHeader.substring(7, authHeader.length)) || undefined;
-      clientOptions['$auth'] = await roomClass['onAuth'](authToken, req);
-    }
-
 
     //
     // isDevMode workaround to allow players to reconnect on devMode

--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -805,6 +805,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
   private async _reserveSeat(
     sessionId: string,
     joinOptions: any = true,
+    authToken: string = undefined,
     seconds: number = this.seatReservationTime,
     allowReconnection: boolean = false,
     devModeReconnection?: boolean,
@@ -826,6 +827,18 @@ export abstract class Room<State extends object= any, Metadata= any> {
 
       this.resetAutoDisposeTimeout(seconds);
     }
+
+
+    /**
+     * Check if static onAuth is implemented (default implementation is just to satisfy TypeScript)
+     * - On "reconnect" requests, the `roomClass` is undefined, as the "roomName" variable actually corresponds to the `roomId`.
+     */
+    if (authToken !== undefined && this.constructor['onAuth'] !== Room['onAuth']) {
+      const authHeader = req.headers['authorization'];
+      const authToken = (authHeader && authHeader.startsWith("Bearer ") && authHeader.substring(7, authHeader.length)) || undefined;
+      clientOptions['$auth'] = await roomClass['onAuth'](authToken, req);
+    }
+
 
     //
     // isDevMode workaround to allow players to reconnect on devMode

--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -359,7 +359,7 @@ export class Server {
             method,
             roomName,
             clientOptions,
-            getBearerToken(req.headers['authorization']),
+            { token: getBearerToken(req.headers['authorization']), request: req },
           );
           res.write(JSON.stringify(response));
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ export { SchemaSerializer } from './serializer/SchemaSerializer';
 
 // Utilities
 export { Clock, Delayed };
-export { generateId, Deferred, DummyServer, spliceOne } from './utils/Utils';
+export { generateId, Deferred, DummyServer, spliceOne, getBearerToken } from './utils/Utils';
 export { isDevMode } from './utils/DevMode';
 
 // Debug

--- a/packages/core/src/matchmaker/controller.ts
+++ b/packages/core/src/matchmaker/controller.ts
@@ -57,13 +57,18 @@ export default {
     return matchMaker.query(conditions);
   },
 
-  async invokeMethod(method: string, roomName: string, clientOptions: any = {}, authToken?: string) {
+  async invokeMethod(
+    method: string,
+    roomName: string,
+    clientOptions: matchMaker.ClientOptions = {},
+    authOptions?: matchMaker.AuthOptions,
+  ) {
     if (this.exposedMethods.indexOf(method) === -1) {
       throw new ServerError(ErrorCode.MATCHMAKE_NO_HANDLER, `invalid method "${method}"`);
     }
 
     try {
-      return await matchMaker[method](roomName, clientOptions, authToken);
+      return await matchMaker[method](roomName, clientOptions, authOptions);
 
     } catch (e) {
       throw new ServerError(e.code || ErrorCode.MATCHMAKE_UNHANDLED, e.message);

--- a/packages/core/src/matchmaker/controller.ts
+++ b/packages/core/src/matchmaker/controller.ts
@@ -57,13 +57,13 @@ export default {
     return matchMaker.query(conditions);
   },
 
-  async invokeMethod(method: string, roomName: string, clientOptions: any = {}) {
+  async invokeMethod(method: string, roomName: string, clientOptions: any = {}, authToken?: string) {
     if (this.exposedMethods.indexOf(method) === -1) {
       throw new ServerError(ErrorCode.MATCHMAKE_NO_HANDLER, `invalid method "${method}"`);
     }
 
     try {
-      return await matchMaker[method](roomName, clientOptions);
+      return await matchMaker[method](roomName, clientOptions, authToken);
 
     } catch (e) {
       throw new ServerError(e.code || ErrorCode.MATCHMAKE_UNHANDLED, e.message);

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -14,7 +14,10 @@ export function generateId(length: number = 9) {
   return nanoid(length);
 }
 
-//
+export function getBearerToken(authHeader: string) {
+  return (authHeader && authHeader.startsWith("Bearer ") && authHeader.substring(7, authorizationHeader.length)) || undefined;
+}
+
 // nodemon sends SIGUSR2 before reloading
 // (https://github.com/remy/nodemon#controlling-shutdown-of-your-script)
 //

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -15,7 +15,7 @@ export function generateId(length: number = 9) {
 }
 
 export function getBearerToken(authHeader: string) {
-  return (authHeader && authHeader.startsWith("Bearer ") && authHeader.substring(7, authorizationHeader.length)) || undefined;
+  return (authHeader && authHeader.startsWith("Bearer ") && authHeader.substring(7, authHeader.length)) || undefined;
 }
 
 // nodemon sends SIGUSR2 before reloading

--- a/packages/transport/bun-websockets/src/BunWebSockets.ts
+++ b/packages/transport/bun-websockets/src/BunWebSockets.ts
@@ -7,7 +7,7 @@ import { ServerWebSocket, WebSocketHandler } from "bun";
 import http from 'http';
 import bunExpress from "bun-serve-express";
 
-import { DummyServer, ErrorCode, matchMaker, Transport, debugAndPrintError, spliceOne, ServerError } from '@colyseus/core';
+import { DummyServer, matchMaker, Transport, debugAndPrintError, spliceOne, ServerError, getBearerToken } from '@colyseus/core';
 import { WebSocketClient, WebSocketWrapper } from './WebSocketClient';
 import { Application, Request, Response } from "express";
 
@@ -191,7 +191,12 @@ export class BunWebSockets extends Transport {
           const roomName = matchedParams[matchmakeIndex + 2] || '';
 
           writeHeaders(req, res);
-          res.json(await matchMaker.controller.invokeMethod(method, roomName, clientOptions));
+          res.json(await matchMaker.controller.invokeMethod(
+            method,
+            roomName,
+            clientOptions,
+            { token: getBearerToken(req.headers['authorization']), request: req },
+          ));
           break;
         }
 

--- a/packages/transport/uwebsockets-transport/src/uWebSocketsTransport.ts
+++ b/packages/transport/uwebsockets-transport/src/uWebSocketsTransport.ts
@@ -255,7 +255,7 @@ export class uWebSocketsTransport extends Transport {
                       method,
                       roomName,
                       clientOptions,
-                      getBearerToken(req.getHeader('authorization'))
+                      { token: getBearerToken(req.getHeader('authorization')), request: req }
                     );
 
                     if (!res.aborted) {


### PR DESCRIPTION
- Fixes https://github.com/colyseus/colyseus/issues/677
- Introduces one last optional argument (`{ token: string, request: any }`) on matchMaker's API, such as `matchMaker.createRoom()`, `matchMaker.create()`, `matchMaker.joinById()`, etc.