### PR TITLE
fixes #717. test file for Stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: test-suite
 on:
+  pull_request:
   push:
     branches:
       - master
       - dev
+
 jobs:
   test-suite:
     name: test-suite

--- a/bundles/colyseus/test/Integration.test.ts
+++ b/bundles/colyseus/test/Integration.test.ts
@@ -3,7 +3,7 @@ import sinon, { match } from "sinon";
 import * as Colyseus from "colyseus.js";
 import { Schema, type, Context } from "@colyseus/schema";
 
-import { matchMaker, Room, Client, Server, ErrorCode, MatchMakerDriver, Presence, Deferred, Transport } from "@colyseus/core";
+import { matchMaker, Room, Client, Server, ErrorCode, MatchMakerDriver, Presence, Deferred, Transport, ClientArray } from "@colyseus/core";
 import { DummyRoom, DRIVERS, timeout, Room3Clients, PRESENCE_IMPLEMENTATIONS, Room2Clients, Room2ClientsExplicitLock } from "./utils";
 import { ServerError, Protocol } from "@colyseus/core";
 
@@ -824,6 +824,31 @@ describe("Integration", () => {
           });
 
           describe("disconnect()", () => {
+            it("should remove room reference", async () => {
+              let roomId: string;
+              const clients: Client[] = [];
+              matchMaker.defineRoomType('disconnect', class _ extends Room {
+                maxClients = 2;
+                onCreate() { roomId = this.roomId; }
+                onJoin(client) { clients.push(client); }
+                async onLeave() { await timeout(5); }
+              });
+
+              const promises = [
+                client.joinOrCreate('disconnect'),
+                client.joinOrCreate('disconnect'),
+              ];
+
+              await Promise.all(promises);
+
+              const room = matchMaker.getRoomById(roomId);
+              assert.strictEqual(room.roomId, roomId);
+
+              await room.disconnect();
+              await timeout(10);
+
+              assert.ok(!matchMaker.getRoomById(roomId));
+            });
 
             it("should disconnect all clients", async() => {
               matchMaker.defineRoomType('disconnect', class _ extends Room {
@@ -1108,7 +1133,6 @@ describe("Integration", () => {
             matchMaker.defineRoomType('async_onjoin', class _ extends Room {
               async onAuth() { return true; }
               async onJoin() {
-                console.log("onJoin called for async onJoin!")
                 onJoinStart.resolve(true);
                 setTimeout(() => {
                   onJoinCompleted = Date.now();
@@ -1186,7 +1210,7 @@ describe("Integration", () => {
 
           });
 
-        })
+        });
 
         describe("reconnection", () => {
 
@@ -1260,45 +1284,6 @@ describe("Integration", () => {
 
             // wait for reconnection to timeout
             await timeout(150);
-            await onRoomDisposed;
-
-            const rooms = await matchMaker.query({});
-            assert.strictEqual(0, rooms.length);
-            assert.strictEqual(0, matchMaker.stats.local.roomCount);
-            assert.strictEqual(0, matchMaker.stats.local.ccu);
-          });
-
-          it("should maintain correct stats on successful reconnections", async () => {
-            const onRoomDisposed = new Deferred();
-            matchMaker.defineRoomType('allow_reconnection', class _ extends Room {
-              async onJoin() {}
-              async onLeave(client, consented) {
-                try {
-                  if (consented) {
-                    throw new Error("consented!");
-                  }
-                  await this.allowReconnection(client, 0.1);
-                } catch (e) {}
-              }
-              onDispose() {
-                onRoomDisposed.resolve();
-              }
-            });
-
-            const roomConnection = await client.joinOrCreate('allow_reconnection');
-
-            assert.strictEqual(1, matchMaker.stats.local.roomCount);
-            assert.strictEqual(1, matchMaker.stats.local.ccu);
-
-            // forcibly close connection
-            roomConnection.connection.transport.close();
-
-            // wait for reconnection to timeout
-            await timeout(5);
-
-            const roomReconnection = await client.reconnect(roomConnection.reconnectionToken);
-            await roomReconnection.leave();
-
             await onRoomDisposed;
 
             const rooms = await matchMaker.query({});

--- a/bundles/colyseus/test/Server.test.ts
+++ b/bundles/colyseus/test/Server.test.ts
@@ -26,7 +26,10 @@ describe("Server", () => {
     server.listen(TEST_PORT, undefined, undefined, resolve);
   }));
 
-  after(() => server.transport.shutdown());
+  after(async () => {
+    await matchMaker.gracefullyShutdown();
+    await server.transport.shutdown()
+  });
 
   describe("matchmaking routes", () => {
 

--- a/bundles/colyseus/test/Stats.test.ts
+++ b/bundles/colyseus/test/Stats.test.ts
@@ -78,7 +78,6 @@ describe("MatchMaker Stats", () => {
       let room: Room;
       const clients: Client[] = [];
       const onReadyToTest = new Deferred();
-      const onDispose = new Deferred();
       matchMaker.defineRoomType('disconnect_joining', class _ extends Room {
         onCreate() {
           room = this;
@@ -92,9 +91,6 @@ describe("MatchMaker Stats", () => {
         }
         async onLeave() {
           await timeout(5);
-        }
-        onDispose() {
-          onDispose.resolve();
         }
       });
 
@@ -110,7 +106,6 @@ describe("MatchMaker Stats", () => {
       assert.strictEqual(0, matchMaker.stats.local.ccu);
 
       await room.disconnect();
-      await onDispose;
       await timeout(100);
 
       assert.strictEqual(0, matchMaker.stats.local.roomCount);

--- a/bundles/colyseus/test/Stats.test.ts
+++ b/bundles/colyseus/test/Stats.test.ts
@@ -1,0 +1,276 @@
+import assert from "assert";
+import { Client, ClientState, Deferred, LocalDriver, LocalPresence, MatchMakerDriver, Presence, Room, Server, Transport, matchMaker } from "@colyseus/core";
+import { WebSocketTransport } from "@colyseus/ws-transport";
+import * as Colyseus from "colyseus.js";
+import { timeout } from "./utils";
+
+const TEST_PORT = 8568;
+const TEST_ENDPOINT = `ws://localhost:${TEST_PORT}`;
+
+describe("MatchMaker Stats", () => {
+  let driver: MatchMakerDriver;
+  let server: Server;
+  let presence: Presence;
+  let transport: Transport;
+
+  const client = new Colyseus.Client(TEST_ENDPOINT);
+
+  before(async () => {
+    driver = new LocalDriver();
+    presence = new LocalPresence();
+    transport = new WebSocketTransport({
+      pingInterval: 100,
+      pingMaxRetries: 3
+    });
+
+    server = new Server({
+      greet: false,
+      gracefullyShutdown: false,
+      presence,
+      driver,
+      transport,
+    });
+
+    // setup matchmaker & listen
+    await matchMaker.setup(presence, driver);
+    await server.listen(TEST_PORT);
+  });
+
+  beforeEach(async() => {
+    await matchMaker.stats.reset();
+    await driver.clear()
+  });
+
+  after(async () => {
+    await driver.clear();
+    await server.gracefullyShutdown(false)
+  });
+
+  describe("disposing the room", () => {
+    it("using .disconnect() w/ 2 clients connected", async () => {
+      let roomId: string;
+      const clients: Client[] = [];
+      matchMaker.defineRoomType('disconnect_stat', class _ extends Room {
+        onCreate() { roomId = this.roomId; }
+        onJoin(client) { clients.push(client); }
+        async onLeave() { await timeout(5); }
+      });
+
+      const promises = [
+        client.joinOrCreate('disconnect_stat'),
+        client.joinOrCreate('disconnect_stat'),
+      ];
+
+      await Promise.all(promises);
+
+      const room = matchMaker.getRoomById(roomId);
+      assert.ok(room);
+
+      await room.disconnect();
+      await timeout(10);
+
+      assert.strictEqual(0, matchMaker.stats.local.roomCount);
+      assert.strictEqual(0, matchMaker.stats.local.ccu);
+      assert.ok(!matchMaker.getRoomById(roomId));
+    });
+
+    it("using .disconnect() while clients are joining", async () => {
+      let room: Room;
+      const clients: Client[] = [];
+      const onReadyToTest = new Deferred();
+      matchMaker.defineRoomType('disconnect_joining', class _ extends Room {
+        onCreate() {
+          room = this;
+        }
+        async onJoin(client) {
+          clients.push(client);
+          setTimeout(() => onReadyToTest.resolve(), 350);
+          await timeout(400);
+        }
+        async onLeave() {
+          await timeout(5);
+        }
+      });
+
+      client.joinOrCreate('disconnect_joining').catch((e) => { });
+      client.joinOrCreate('disconnect_joining').catch((e) => { });
+      client.joinOrCreate('disconnect_joining').catch((e) => { });
+
+      await onReadyToTest;
+      // await timeout(390);
+
+      assert.strictEqual(3, clients.length, "3 clients should be joining");
+
+      assert.strictEqual(1, matchMaker.stats.local.roomCount);
+      assert.strictEqual(0, matchMaker.stats.local.ccu);
+
+      await room.disconnect();
+      await timeout(100);
+
+      assert.strictEqual(0, matchMaker.stats.local.roomCount);
+      assert.strictEqual(0, matchMaker.stats.local.ccu);
+    });
+
+    it("using client.leave() before 'onJoin' finishes", async () => {
+      const clients: Client[] = [];
+      const onReadyToTest = new Deferred();
+      const onRoomDisposed = new Deferred();
+
+      matchMaker.defineRoomType('manual_leave', class _ extends Room {
+        async onJoin(client) {
+          clients.push(client);
+          setTimeout(() => onReadyToTest.resolve(), 250);
+          await timeout(300);
+        }
+        async onLeave(client, consented) {}
+        onDispose() { onRoomDisposed.resolve(); }
+      });
+
+      const clientConnections: Promise<any>[] = [];
+      clientConnections.push(client.joinOrCreate('manual_leave').catch((e) => { }));
+      clientConnections.push(client.joinOrCreate('manual_leave').catch((e) => { }));
+
+      // wait for all clients to be "joining"
+      await onReadyToTest;
+      // await timeout(250);
+
+      assert.strictEqual(1, matchMaker.stats.local.roomCount);
+      assert.strictEqual(0, matchMaker.stats.local.ccu);
+
+      assert.strictEqual(2, clients.filter((client) => client.state === ClientState.JOINING).length);
+
+      // call 'leave' before 'onJoin' finishes
+      clients.map((client) => client.leave());
+
+      await onRoomDisposed;
+
+      assert.strictEqual(0, matchMaker.stats.local.roomCount);
+      assert.strictEqual(0, matchMaker.stats.local.ccu);
+    });
+
+
+    it("triggering error during 'onLeave'", async () => {
+      const ROOM_NAME = 'error_onleave';
+
+      const clients: Client[] = [];
+      const onReadyToTest = new Deferred();
+      const onRoomDisposed = new Deferred();
+      matchMaker.defineRoomType(ROOM_NAME, class _ extends Room {
+        async onJoin(client) {
+          clients.push(client);
+          setTimeout(() => onReadyToTest.resolve(), 390);
+          await timeout(400);
+        }
+        async onLeave(client, consented) {
+          await timeout(10);
+          throw new Error("onLeave error");
+        }
+        onDispose() {
+          onRoomDisposed.resolve();
+        }
+      });
+
+      const clientConnections: Promise<any>[] = [];
+      clientConnections.push(client.joinOrCreate(ROOM_NAME).catch((e) => {}));
+      clientConnections.push(client.joinOrCreate(ROOM_NAME).catch((e) => {}));
+      clientConnections.push(client.joinOrCreate(ROOM_NAME).catch((e) => {}));
+
+      // wait for successful join
+      await Promise.all(clientConnections);
+
+      assert.strictEqual(1, matchMaker.stats.local.roomCount);
+      assert.strictEqual(3, matchMaker.stats.local.ccu);
+
+      // leave all clients
+      clients.map((client) => client.leave());
+
+      await onRoomDisposed;
+      await timeout(100);
+
+      assert.strictEqual(0, matchMaker.stats.local.roomCount);
+      assert.strictEqual(0, matchMaker.stats.local.ccu);
+    });
+
+    it("triggering error during 'onLeave' before 'onJoin' finishes", async () => {
+      const ROOM_NAME = 'error_onleave';
+
+      const clients: Client[] = [];
+      const onReadyToTest = new Deferred();
+      const onRoomDisposed = new Deferred();
+      matchMaker.defineRoomType(ROOM_NAME, class _ extends Room {
+        async onJoin(client) {
+          clients.push(client);
+          setTimeout(() => onReadyToTest.resolve(), 390);
+          await timeout(400);
+        }
+        async onLeave(client, consented) {
+          await timeout(10);
+          throw new Error("onLeave error");
+        }
+        onDispose() {
+          onRoomDisposed.resolve();
+        }
+      });
+
+      client.joinOrCreate(ROOM_NAME).catch((e) => { })
+      client.joinOrCreate(ROOM_NAME).catch((e) => { })
+
+      await onReadyToTest;
+      // await timeout(300);
+
+      assert.strictEqual(1, matchMaker.stats.local.roomCount);
+      assert.strictEqual(0, matchMaker.stats.local.ccu);
+
+      // call 'leave' before 'onJoin' finishes
+      clients.map((client) => client.leave());
+
+      await onRoomDisposed;
+
+      assert.strictEqual(0, matchMaker.stats.local.roomCount);
+      assert.strictEqual(0, matchMaker.stats.local.ccu);
+    });
+
+  })
+
+  it("should maintain stats on reconnection", async () => {
+    const onRoomDisposed = new Deferred();
+    matchMaker.defineRoomType('allow_reconnection', class _ extends Room {
+      async onJoin() { }
+      async onLeave(client, consented) {
+        try {
+          if (consented) {
+            throw new Error("consented!");
+          }
+          await this.allowReconnection(client, 0.1);
+        } catch (e) { }
+      }
+      onDispose() {
+        onRoomDisposed.resolve();
+      }
+    });
+
+    const roomConnection = await client.joinOrCreate('allow_reconnection');
+
+    assert.strictEqual(1, matchMaker.stats.local.roomCount);
+    assert.strictEqual(1, matchMaker.stats.local.ccu);
+
+    // forcibly close connection
+    roomConnection.connection.transport.close();
+
+    // wait for reconnection to timeout
+    await timeout(5);
+
+    const roomReconnection = await client.reconnect(roomConnection.reconnectionToken);
+    assert.strictEqual(1, matchMaker.stats.local.roomCount);
+    assert.strictEqual(1, matchMaker.stats.local.ccu);
+    await roomReconnection.leave();
+
+    await onRoomDisposed;
+
+    const rooms = await matchMaker.query({});
+    assert.strictEqual(0, rooms.length);
+    assert.strictEqual(0, matchMaker.stats.local.roomCount);
+    assert.strictEqual(0, matchMaker.stats.local.ccu);
+  });
+
+});

--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -492,7 +492,14 @@ export async function handleCreateRoom(roomName: string, clientOptions: ClientOp
   room._events.on('leave', onClientLeaveRoom.bind(this, room));
   room._events.on('visibility-change', onVisibilityChange.bind(this, room));
   room._events.once('dispose', disposeRoom.bind(this, roomName, room));
-  room._events.once('disconnect', () => room._events.removeAllListeners());
+
+  // when disconnect()'ing, keep only join/leave events for stat counting
+  room._events.once('disconnect', () => {
+    room._events.removeAllListeners('lock');
+    room._events.removeAllListeners('unlock');
+    room._events.removeAllListeners('visibility-change');
+    room._events.removeAllListeners('dispose');
+  });
 
   // room always start unlocked
   await createRoomReferences(room, true);

--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -705,7 +705,7 @@ function onVisibilityChange(room: Room, isInvisible: boolean): void {
 }
 
 async function disposeRoom(roomName: string, room: Room) {
-  debugMatchMaking('disposing \'%s\' (%s) on processId \'%s\'', roomName, room.roomId, processId);
+  debugMatchMaking('disposing \'%s\' (%s) on processId \'%s\' (graceful shutdown: %s)', roomName, room.roomId, processId, isGracefullyShuttingDown);
 
   // decrease amount of rooms this process is handling
   if (!isGracefullyShuttingDown) {


### PR DESCRIPTION
Fixes https://github.com/colyseus/colyseus/issues/717 

Tests are passing when isolated but they fail on the full test suite. Need to check why.

- Keep listening to 'join' and 'leave' messages from MatchMaker during "disconnect" event https://github.com/colyseus/colyseus/blob/75246ed382ef7f5715b73af33f7fca1911c5b72f/packages/core/src/MatchMaker.ts#L496-L502
- Only trigger 'leave' event if seat reservation was successfully consumed https://github.com/colyseus/colyseus/blob/75246ed382ef7f5715b73af33f7fca1911c5b72f/packages/core/src/Room.ts#L1023-L1026