### PR TITLE
[bun-transport] fix parsing body string to JSON in Matchmaker

### DIFF
--- a/packages/transport/bun-websockets/src/BunWebSockets.ts
+++ b/packages/transport/bun-websockets/src/BunWebSockets.ts
@@ -4,12 +4,12 @@
 // @ts-ignore
 import { ServerWebSocket, WebSocketHandler } from "bun";
 
-import http from 'http';
+import type http from 'http';
 import bunExpress from "bun-serve-express";
 
 import { DummyServer, matchMaker, Transport, debugAndPrintError, spliceOne, ServerError, getBearerToken } from '@colyseus/core';
 import { WebSocketClient, WebSocketWrapper } from './WebSocketClient';
-import { Application, Request, Response } from "express";
+import type { Application, Request, Response } from "express";
 
 export type TransportOptions = Partial<Omit<WebSocketHandler, "message" | "open" | "drain" | "close" | "ping" | "pong">>;
 
@@ -181,10 +181,16 @@ export class BunWebSockets extends Transport {
 
           const matchedParams = req.path.match(matchMaker.controller.allowedRoomNameChars);
           const matchmakeIndex = matchedParams.indexOf(matchMaker.controller.matchmakeRoute);
-          const clientOptions = req.body; // Bun.readableStreamToJSON(req.body);
+          let clientOptions = req.body; // Bun.readableStreamToJSON(req.body);
 
-          if (clientOptions === undefined) {
+          if (clientOptions == null) {
             throw new ServerError(500, "invalid JSON input");
+          }
+
+          if (typeof clientOptions === 'string' && clientOptions.length > 2) {
+            clientOptions = JSON.parse(clientOptions);
+          } else if (typeof clientOptions !== 'object') {
+            clientOptions = {};
           }
 
           const method = matchedParams[matchmakeIndex + 1];


### PR DESCRIPTION
onCreate/onJoin  `options` parameter's type is string now, but must be an object.

The problem was in matchmaker. It doesn't convert string body to json object.