### PR TITLE
Draft - Adding matchmaker callback for advanced filtering

### DIFF
--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -265,12 +265,15 @@ export async function findOneRoomAvailable(roomName: string, clientOptions: Clie
   return await awaitRoomAvailable(roomName, async () => {
     const handler = getHandler(roomName);
 
+    // Ohki - Code Review Question: Cleanest way to pass filterCallback to Query?
+    // As a new parameter, it allows it to be optional. 
+    // I did not want to alter the IRoomListingData interface, but including it in the partial interface also makes sense. 
     const roomQuery = driver.findOne({
       locked: false,
       name: roomName,
       private: false,
       ...handler.getFilterOptions(clientOptions),
-    });
+    }, handler.filterCallback);
 
     if (handler.sortOptions) {
       roomQuery.sort(handler.sortOptions);
@@ -333,6 +336,7 @@ export function defineRoomType<T extends Type<Room>>(
   klass: T,
   defaultOptions?: Parameters<NonNullable<InstanceType<T>['onCreate']>>[0],
 ) {
+
   const registeredHandler = new RegisteredHandler(klass, defaultOptions);
 
   handlers[roomName] = registeredHandler;

--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -336,7 +336,6 @@ export function defineRoomType<T extends Type<Room>>(
   klass: T,
   defaultOptions?: Parameters<NonNullable<InstanceType<T>['onCreate']>>[0],
 ) {
-
   const registeredHandler = new RegisteredHandler(klass, defaultOptions);
 
   handlers[roomName] = registeredHandler;

--- a/packages/core/src/matchmaker/RegisteredHandler.ts
+++ b/packages/core/src/matchmaker/RegisteredHandler.ts
@@ -55,6 +55,7 @@ export class RegisteredHandler extends EventEmitter {
     });
     this.on('dispose', (room) => updateLobby(room, false));
     this.on('visibility-change', (room, isVisible) => updateLobby(room, isVisible));
+
     return this;
   }
 

--- a/packages/core/src/matchmaker/RegisteredHandler.ts
+++ b/packages/core/src/matchmaker/RegisteredHandler.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage } from 'http';
 import { EventEmitter } from 'events';
 import { logger } from '../Logger';
-import { RoomListingData, SortOptions } from './driver/interfaces';
+import { FilterCallback, RoomListingData, SortOptions } from './driver/interfaces';
 
 import { Room } from './../Room';
 import { updateLobby } from './Lobby';
@@ -29,6 +29,7 @@ export class RegisteredHandler extends EventEmitter {
 
   public filterOptions: string[] = [];
   public sortOptions?: SortOptions;
+  public filterCallback: FilterCallback;
 
   constructor(klass: Type<Room>, options: any) {
     super();
@@ -54,7 +55,6 @@ export class RegisteredHandler extends EventEmitter {
     });
     this.on('dispose', (room) => updateLobby(room, false));
     this.on('visibility-change', (room, isVisible) => updateLobby(room, isVisible));
-
     return this;
   }
 
@@ -65,6 +65,11 @@ export class RegisteredHandler extends EventEmitter {
 
   public sortBy(options: SortOptions) {
     this.sortOptions = options;
+    return this;
+  }
+
+  public filterMethod(filterCallback: FilterCallback) {
+    this.filterCallback = filterCallback ? filterCallback : null;
     return this;
   }
 

--- a/packages/core/src/matchmaker/driver/Query.ts
+++ b/packages/core/src/matchmaker/driver/Query.ts
@@ -62,7 +62,6 @@ export class Query<T> implements QueryHelpers<T> {
           return false; 
         }
       }
-
       return true;
     }));
     return resolve(result);

--- a/packages/core/src/matchmaker/driver/Query.ts
+++ b/packages/core/src/matchmaker/driver/Query.ts
@@ -1,12 +1,14 @@
-import { QueryHelpers, SortOptions } from './interfaces';
+import { FilterCallback, QueryHelpers, SortOptions } from './interfaces';
 
 export class Query<T> implements QueryHelpers<T> {
   private $rooms: T[];
   private conditions: any;
+  private filterMethod: FilterCallback;
 
-  constructor(rooms: any[], conditions) {
+  constructor(rooms: any[], conditions, filterMethod?: FilterCallback) {
     this.$rooms = rooms.slice(0);
     this.conditions = conditions;
+    this.filterMethod = filterMethod || null;
   }
 
   public sort(options: SortOptions) {
@@ -31,14 +33,36 @@ export class Query<T> implements QueryHelpers<T> {
 
   public then(resolve, reject) {
     const result: any = this.$rooms.find(((room) => {
-      for (const field in this.conditions) {
-        if (
-          this.conditions.hasOwnProperty(field) &&
-          room[field] !== this.conditions[field]
-        ) {
-          return false;
+      if (this.filterMethod === null) {
+        // If no filterMethod is provided, use default behavior.
+        for (const field in this.conditions) {
+          if (
+            this.conditions.hasOwnProperty(field) &&
+            room[field] !== this.conditions[field]
+          ) {
+            return false;
+          }
+        }
+      } else if (
+        room['locked'] !==  this.conditions['locked'] ||
+        room['name'] !==  this.conditions['name'] ||
+        room['private'] !==  this.conditions['private']
+      ) {
+        // A filterMethod was provided.
+        // We manually filter for locked, name and private. 
+        // If locked, name or private do not match, there is no reason to proceed.
+        return false;
+      } else {
+        // A filterMethod is provided and lock, name and private tested valid. 
+        // We send conditions and room feilds back to the callback method.
+        const callbackResult = this.filterMethod(this.conditions, room);
+
+        // Return false when callback returns type-matched false.
+        if (callbackResult === false) { 
+          return false; 
         }
       }
+
       return true;
     }));
     return resolve(result);

--- a/packages/core/src/matchmaker/driver/index.ts
+++ b/packages/core/src/matchmaker/driver/index.ts
@@ -1,8 +1,8 @@
 import { logger } from "../../Logger";
-import { IRoomListingData, SortOptions, RoomListingData, QueryHelpers, MatchMakerDriver } from "./interfaces";
+import { FilterCallback, IRoomListingData, SortOptions, RoomListingData, QueryHelpers, MatchMakerDriver } from "./interfaces";
 
 // re-export
-export type { IRoomListingData, SortOptions, RoomListingData, QueryHelpers, MatchMakerDriver };
+export type { FilterCallback, IRoomListingData, SortOptions, RoomListingData, QueryHelpers, MatchMakerDriver };
 
 import { Query } from './Query';
 import { RoomCache } from './RoomData';
@@ -40,8 +40,9 @@ export class LocalDriver implements MatchMakerDriver {
     return Promise.resolve();
   }
 
-  public findOne(conditions: Partial<IRoomListingData>) {
-    return new Query<RoomListingData>(this.rooms, conditions) as any as QueryHelpers<RoomListingData>;
+  // Ohki - Code Review Question: I mentioned in MatchMakter.ts, this could be an optional property or an update to IRoomListingData.
+  public findOne(conditions: Partial<IRoomListingData>, filterMethod?: FilterCallback) {
+    return new Query<RoomListingData>(this.rooms, conditions, filterMethod) as any as QueryHelpers<RoomListingData>;
   }
 
   public clear() {

--- a/packages/core/src/matchmaker/driver/interfaces.ts
+++ b/packages/core/src/matchmaker/driver/interfaces.ts
@@ -72,7 +72,7 @@ export interface MatchMakerDriver {
    *
    * @returns `RoomListingData` - An object contaning filtered room metadata.
    */
-  findOne(conditions: Partial<IRoomListingData>): QueryHelpers<RoomListingData>;
+  findOne(conditions: Partial<IRoomListingData>, filterMethod?: FilterCallback): QueryHelpers<RoomListingData>;
 
   /**
    * Empty the room cache.
@@ -84,3 +84,7 @@ export interface MatchMakerDriver {
    */
   shutdown(): void;
 }
+
+// Ohki - Code review question: What is the correct location for shared types? 
+export type FilterCallback = (clientOptions?: any, roomOptions?: any) => boolean | null;
+


### PR DESCRIPTION
## Summary

Enables the option to pass a filter callback when defining a room in Colyseus. 

DRAFT - Awaiting code review and approval.   

TODO - Unit tests. 

## Author Code-Review Questions Questions

The following questions are also noted as inline comments in the code. 

- I defined a new type in interfaces.ts. Types are not defined here, but I was not sure of a more appropriate location to define the time that is referenced throughout this process.
- I added an optional property to the `findOne` method and the `Query` class. This seemed like a minimally intrusive approach, but I considered the new value could be added to the IRoomListingData interface, which is passed as a partial. 
- I used the name "filterMethod" as the user-facing property to define a callback used for filtering, while I defined the type name as "filterCallback" elsewhere in the code. Requesting feedback on Colyseus expectations for user-facing and internal variable naming. 

## Changes

/MatchMater.ts
- Passes `filterCallback` to `findOne` method in `awaitRoomAvailable`

/matchmaker/RegisteredHandler.ts
- Receives `filterCallback` from server define if provided, uses `null` if not provided.

/matchmaker/driver/Query.ts
- Adds logic to use `filterCallback` if it is defined.
- If `filterCallback` is null, use existing behavior. 
- If `filterCallback` is defined, first manually check `locked`, `name` and `private`.
- If `locked`, `name` and `private` pass, provide instance options and room options to `filterCallback`.
- If `filterCallback` returns strict boolean false, return false for this room filter check.
- Proceed with room filter loop process.

/matchmaker/driver/index.ts
- Adds `filterMethod` as a property to `Query` method when `FindOne` method is called. 

/matchmaker/driver/interfaces.ts
- Adds `filterMethod` as an optional property to the `findOne` interface. 
- Defines the type `FilterMethod` as function with `clientOptions` and `roomOptions` optional properties, that returns strict boolean, or null. 

## Intended implementation example

```
const filterMethod = (instanceOptions: any, roomOptions: any): boolean => {
  return 
    instanceOptions.alpha !== roomOptions.beta && 
    instanceOptions.gamma === roomOptions.gamma;
} 

initializeGameServer: (gameServer) => {
  gameServer.define('MyRoom', MyRoom).filterBy(['alpha','beta','gamma']).filterMethod(filterCallback);
}
```