### PR TITLE
allow error handling on sendFullState

### DIFF
--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -812,7 +812,7 @@ export abstract class Room<State extends object= any, Metadata= any> {
     }
   }
 
-  private sendFullState(client: Client): void {
+  protected sendFullState(client: Client): void {
     client.enqueueRaw(getMessageBytes[Protocol.ROOM_STATE](this._serializer.getFullState(client)));
   }
 


### PR DESCRIPTION
because sendFullState is private, there is not an elegant way to prevent server crashes if the room state gets corrupted.
By making this method protected, we can override it and add exception handling, to shut down the room gracefully and keep all other rooms running normally.