### PR TITLE
loadtest: Also wrap create & joinById for tracking stats

### DIFF
--- a/packages/loadtest/src/index.ts
+++ b/packages/loadtest/src/index.ts
@@ -460,9 +460,23 @@ Example:
         return room;
     }
 
+    const _originalCreate = Client.prototype.create;
+    Client.prototype.create = async function(this: Client) {
+        const room = await _originalCreate.apply(this, arguments);
+        handleClientJoin(room);
+        return room;
+    }
+    
     const _originalJoin = Client.prototype.join;
     Client.prototype.join = async function(this: Client) {
         const room = await _originalJoin.apply(this, arguments);
+        handleClientJoin(room);
+        return room;
+    }
+
+    const _originalJoinById = Client.prototype.joinById;
+    Client.prototype.joinById = async function(this: Client) {
+        const room = await _originalJoinById.apply(this, arguments);
         handleClientJoin(room);
         return room;
     }


### PR DESCRIPTION
Currently only `joinOrCreate` and `join` are being wrapped, but I typically use `create` and `joinById` in my app. Those also need to be wrapped the same way, I think.