### PR TITLE
loadtest: Modernize package.json to properly support ESM

### DIFF
--- a/packages/loadtest/package.json
+++ b/packages/loadtest/package.json
@@ -2,6 +2,14 @@
   "name": "@colyseus/loadtest",
   "version": "0.15.5",
   "description": "Utility tool for load testing Colyseus.",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "require": "./build/index.js",
+      "import": "./build/index.mjs"
+    }
+  },
   "input": "./src/index.ts",
   "main": "./build/index.js",
   "module": "./build/index.mjs",


### PR DESCRIPTION
See comments in https://github.com/colyseus/colyseus/pull/752#issuecomment-2245880073

Since `type` & `exports` were missing, my project was importing the CommonJS build instead of the ESM one, using Node v22. Adding these in makes the `Client.prototype` stuff work correctly because it overrides the same functions that my project is actually using.