### PR TITLE
Add callback before gracefully shutdown server

### DIFF
--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -248,6 +248,7 @@ export class Server {
     });
 
     try {
+      await this.onBeforeShutdownCallback();
       await matchMaker.gracefullyShutdown();
       this.transport.shutdown();
       this.presence.shutdown();
@@ -301,11 +302,18 @@ export class Server {
     this.onShutdownCallback = callback;
   }
 
+  public onBeforeShutdown(callback: () => void | Promise<any>) {
+    this.onBeforeShutdownCallback = callback;
+  }
+
   protected getDefaultTransport(_: any): Transport {
     throw new Error("Please provide a 'transport' layer. Default transport not set.");
   }
 
   protected onShutdownCallback: () => void | Promise<any> =
+    () => Promise.resolve()
+
+  protected onBeforeShutdownCallback: () => void | Promise<any> =
     () => Promise.resolve()
 
   protected attachMatchMakingRoutes(server: http.Server) {


### PR DESCRIPTION
### WHY
Currently the server is unable to exclude process safely on shutdown. In order NOT to break current gracefully shutdown process I think it needs another shutdown callback to do something before "official" shutdown process.

Here's use case.

```
server.onBeforeShutdown(async () => {
  // Exclude self from match maker
  await matchMaker.stats.excludeProcess(matchMaker.processId);

  // wait until room count goes to 0 (let players continue to play)
  while (matchMaker.stats.local.roomCount > 0) {
    await new Promise((resolve) => setTimeout(resolve, 100));
  }
})
```

### WHAT
Simple added `onBeforeShutdown` lifecycle callback

---

IMO `await this.onShutdownCallback();` must called before `await matchMaker.gracefullyShutdown();`. If match maker removes all rooms and presence, there's almost nothing to process about the rooms.