### PR TITLE
Restore package.json for CJS support.

### DIFF
--- a/packages/loadtest/package.json
+++ b/packages/loadtest/package.json
@@ -2,7 +2,7 @@
   "name": "@colyseus/loadtest",
   "version": "0.15.6",
   "description": "Utility tool for load testing Colyseus.",
-  "type": "module",
+  "type": "commonjs",
   "exports": {
     ".": {
       "types": "./build/index.d.ts",


### PR DESCRIPTION
Revert change from: https://github.com/colyseus/colyseus/pull/753/files Since this fully breaks CJS support.
Considering main is set to be the CJS entry: 
"main": "./build/index.js",
Then the package type must remain as commonjs otherwise you can't "require" it.