### PR TITLE
loadtest: Add clientId to identify each client in logs

### DIFF
--- a/packages/loadtest/src/index.ts
+++ b/packages/loadtest/src/index.ts
@@ -23,6 +23,7 @@ export type Options = {
     retryFailed: number,
     output: string,
     requestJoinOptions?: RequestJoinOperations,
+    clientId: number,
 };
 
 export type MainCallback = (options: Options) => Promise<void>;
@@ -93,6 +94,7 @@ Example:
         reestablishAllDelay: argv.reestablishAllDelay || 0,
         retryFailed: argv.retryFailed || 0,
         output: argv.output && path.resolve(argv.output),
+        clientId: 0,
     }
 
     if (!main) {
@@ -395,7 +397,7 @@ Example:
 
     async function connect(main: MainCallback, i: number) {
         try {
-            await main(options);
+            await main({ ...options, clientId: i });
         } catch (e) {
             handleError(e);
         }


### PR DESCRIPTION
In my logs, I want to be able to tell apart which client replica is which, and currently there's no way to do so. Simple thing is to simply pass the index in the `options` which is available to `main()`.