### PR TITLE
`Auth#onFindUserByEmail` does not mutate the returned data.

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -177,7 +177,7 @@ Please give feedback and report any issues you may find at https://github.com/co
         const email = req.body.email;
         if (!isValidEmail(email)) { throw new Error("email_malformed"); }
 
-        const user = await auth.settings.onFindUserByEmail(email);
+        const user = Object.assign({}, await auth.settings.onFindUserByEmail(email));
         if (user && user.password === await Hash.make(req.body.password)) {
           delete user.password; // remove password from JWT payload
           res.json({ user, token: await auth.settings.onGenerateToken(user) });
@@ -236,7 +236,7 @@ Please give feedback and report any issues you may find at https://github.com/co
         // Register
         await auth.settings.onRegisterWithEmailAndPassword(email, await Hash.make(password), options);
 
-        const user = await auth.settings.onFindUserByEmail(email);
+        const user = Object.assign({}, await auth.settings.onFindUserByEmail(email));
         delete user.password; // remove password from JWT payload
 
         const token = await auth.settings.onGenerateToken(user);

--- a/packages/auth/test/Authentication.test.ts
+++ b/packages/auth/test/Authentication.test.ts
@@ -1,0 +1,104 @@
+import assert from "assert";
+import type http from "http";
+import * as httpie from "httpie";
+import { JWT, auth, Hash } from "../src/index";
+import express from "express";
+
+const TEST_PORT = 8888;
+
+function get(segments: string, opts: Partial<httpie.Options> = undefined) {
+  return httpie.get(`http://localhost:${TEST_PORT}${segments}`, opts);
+}
+function post(segments: string, opts: Partial<httpie.Options> = undefined) {
+  return httpie.post(`http://localhost:${TEST_PORT}${segments}`, opts);
+}
+
+const email = "endel@colyseus.io";
+const password = "123456";
+
+// JWT Secret for testing
+// JWT.options.verify.algorithms = ['HS512'];
+JWT.settings.secret = "@%^&";
+
+class DB {
+  db: Map<number, any>;
+
+  constructor() {
+    this.db = new Map();
+  }
+  async findUserByEmail(email: string) {
+    const user = Array
+      .from(this.db.values())
+      .find((u) => u.email === email);
+    return user;
+  }
+  async createUser(data: any) {
+    const user = {
+      ...data,
+      id: this.db.size + 1,
+    };
+    this.db.set(user.id, user);
+    return user;
+  }
+  clear() {
+    this.db.clear();
+  }
+}
+
+describe("Auth:onFindUserByEmail", () => {
+  let app: ReturnType<typeof express>;
+  let server: http.Server;
+  const db = new DB();
+
+  beforeEach(async () => {
+    app = express();
+    app.use(auth.prefix, auth.routes({
+      onRegisterWithEmailAndPassword: async (email, password, options) => {
+        return db.createUser({ ...options, email, password });
+      },
+  
+      onFindUserByEmail: async (email: string) => {
+        return db.findUserByEmail(email) as Promise<{ password: string }>;
+      },
+    }));
+
+    db.clear();
+
+    return new Promise((resolve) => {
+      server = app.listen(TEST_PORT, () => resolve() );
+    })
+  });
+
+  afterEach(async () => {
+    server.close();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+
+  it("login: should not mutate the user object", async () => {
+    await db.createUser({ email, password: await Hash.make(password) });
+
+    const login = await post("/auth/login", {
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email,
+        password,
+      }),
+    });
+    const user = await db.findUserByEmail(email);
+    assert.equal(user.password, await Hash.make(password));
+    assert.equal(login.data.user.password, undefined);
+  });
+
+  it("register: should not mutate the user object", async () => {
+    const register = await post("/auth/register", {
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email,
+        password,
+      }),
+    });
+    const user = await db.findUserByEmail(email);
+    assert.equal(user.password, await Hash.make(password));
+    assert.equal(register.data.user.password, undefined);
+  });
+});


### PR DESCRIPTION
### Issue
```ts
import auth from "@colyseus/auth";

const db = [
  { id: 1, email: "random@mail.com", password: "1234" }
];

auth.settings.onFindUserByEmail = async (email: string) => {
  const user = db.find((user) => user.email === email);
  return user;
  // After `auth` calls this function it will `delete user.password` mutating the object we are returning here.
}
```

I know that most of the cases it won't affect because we will be using a DB instead an instance variable, but would be nice to prevent this. 😄