### PR TITLE
Pass clientOptions to callOnAuth

### DIFF
--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -223,7 +223,7 @@ export async function create(roomName: string, clientOptions: ClientOptions = {}
  */
 export async function join(roomName: string, clientOptions: ClientOptions = {}, authOptions?: AuthContext) {
   return await retry<Promise<SeatReservation>>(async () => {
-    const authData = await callOnAuth(roomName, authOptions);
+    const authData = await callOnAuth(roomName, clientOptions, authOptions);
     const room = await findOneRoomAvailable(roomName, clientOptions);
 
     if (!room) {
@@ -286,7 +286,7 @@ export async function joinById(roomId: string, clientOptions: ClientOptions = {}
     throw new ServerError(ErrorCode.MATCHMAKE_INVALID_ROOM_ID, `room "${roomId}" is locked`);
   }
 
-  const authData = await callOnAuth(room.name, authOptions);
+  const authData = await callOnAuth(room.name, clientOptions, authOptions);
 
   return reserveSeatFor(room, clientOptions, authData);
 }


### PR DESCRIPTION
Fixes https://discord.com/channels/525739117951320081/1341559392553668670
Joining a room via the ID throws the following error without this change:
```
TypeError: Cannot read properties of undefined (reading 'token')
    at callOnAuth (node_modules\@colyseus\core\build\MatchMaker.js:465:131)
    at Object.joinById (node_modules\@colyseus\core\build\MatchMaker.js:215:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Object.invokeMethod (node_modules\@colyseus\core\build\matchmaker\controller.js:74:14)
    at async IncomingMessage.<anonymous> (node_modules\@colyseus\core\build\Server.js:233:28)
```
