### PR TITLE
allow for manually passing in a sessionId during the reserveSeatFor h…

### DIFF
--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -710,7 +710,7 @@ export async function gracefullyShutdown(): Promise<any> {
  * Reserve a seat for a client in a room
  */
 export async function reserveSeatFor(room: IRoomCache, options: ClientOptions, authData?: any) {
-  const sessionId: string = generateId();
+  const sessionId: string = authData?.sessionId || generateId();
 
   debugMatchMaking(
     'reserving seat. sessionId: \'%s\', roomId: \'%s\', processId: \'%s\'',

--- a/packages/core/src/Transport.ts
+++ b/packages/core/src/Transport.ts
@@ -26,7 +26,7 @@ export interface ISendOptions {
   afterNextPatch?: boolean;
 }
 
-export enum ClientState { JOINING, JOINED, RECONNECTED, LEAVING }
+export enum ClientState { JOINING, JOINED, RECONNECTED, LEAVING, CLOSED }
 
 /**
  * The client instance from the server-side is responsible for the transport layer between the server and the client.


### PR DESCRIPTION
…ook via the authData as authData should be verified by that point. This allows for users to manually control the sessionId via the onAuth hook which adds lots of flexibility to transport methods.