### PR TITLE
expose Presence setMaxListeners

### DIFF
--- a/packages/core/src/presence/LocalPresence.ts
+++ b/packages/core/src/presence/LocalPresence.ts
@@ -283,6 +283,10 @@ export class LocalPresence implements Presence {
       }
     }
 
+    public setMaxListeners(number: number) {
+      this.channels.setMaxListeners(number);
+    }
+
     public shutdown() {
       if (isDevMode) {
         const cache = JSON.stringify({

--- a/packages/core/src/presence/Presence.ts
+++ b/packages/core/src/presence/Presence.ts
@@ -213,5 +213,7 @@ export interface Presence {
      */
     brpop(...args: [...keys: string[], timeoutInSeconds: number]): Promise<[string, string] | null>;
 
+    setMaxListeners(number: number): void;
+
     shutdown(): void;
 }

--- a/packages/presence/redis-presence/src/index.ts
+++ b/packages/presence/redis-presence/src/index.ts
@@ -197,6 +197,10 @@ export class RedisPresence implements Presence {
         this.pub.quit();
     }
 
+    public setMaxListeners(number: number) {
+      this.channels.setMaxListeners(number);
+    }
+
     protected handleSubscription = (channel, message) => {
         this.channels.emit(channel, JSON.parse(message));
     }


### PR DESCRIPTION
Node EventEmitter used in Presence has a built-in maxListeners used to try to detect and prevent memory leaks. Its default value is 10 listeners, which is short when you have more than 10 rooms that need:

>  (node:85265) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 server-announcement listeners added to [EventEmitter]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit

Problem is the emitter is not exposed by Presence, so there's no way to call this setMaxListeners method from colyseus.

This PR exposes this setMaxListeners method so that we can set the presence maxListeners without changing the default value for all EventEmitters.