### PR TITLE
filterBy() and sortBy(): improve type inference from OnCreateOptions<Room>

### DIFF
--- a/bundles/colyseus/test/MatchMaker.test.ts
+++ b/bundles/colyseus/test/MatchMaker.test.ts
@@ -25,7 +25,7 @@ describe("MatchMaker", () => {
 
         matchMaker
           .defineRoomType("room2_filtered", Room2Clients)
-          .filterBy(['mode']);
+          .filterBy(['mode'])
 
         matchMaker
           .defineRoomType("room3_sorted_desc", Room3Clients)

--- a/bundles/colyseus/test/utils/index.ts
+++ b/bundles/colyseus/test/utils/index.ts
@@ -151,7 +151,7 @@ export class DummyRoom extends Room {
 export class Room2Clients extends Room {
   maxClients = 2;
 
-  onCreate(options: any) {
+  onCreate(options: { mode: string, roomId?: string }) {
     if (options.roomId) { this.roomId = options.roomId; }
     this.onMessage("*", (_, type, message) => {
       this.broadcast(type, message);

--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -7,7 +7,7 @@ import { Deferred, generateId, merge, retry, MAX_CONCURRENT_CREATE_ROOM_WAIT_TIM
 import { isDevMode, cacheRoomHistory, getPreviousProcessId, getRoomRestoreListKey, reloadFromCache } from './utils/DevMode.js';
 
 import { RegisteredHandler } from './matchmaker/RegisteredHandler.js';
-import { Room, RoomInternalState } from './Room.js';
+import { OnCreateOptions, Room, RoomInternalState } from './Room.js';
 
 import { LocalPresence } from './presence/LocalPresence.js';
 import { Presence } from './presence/Presence.js';
@@ -378,7 +378,7 @@ export async function remoteRoomCall<R= any>(
 export function defineRoomType<T extends Type<Room>>(
   roomName: string,
   klass: T,
-  defaultOptions?: Parameters<NonNullable<InstanceType<T>['onCreate']>>[0],
+  defaultOptions?: OnCreateOptions<T>,
 ) {
   const registeredHandler = new RegisteredHandler(roomName, klass, defaultOptions);
 

--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -14,6 +14,7 @@ import { Serializer } from './serializer/Serializer.js';
 import { ErrorCode, getMessageBytes, Protocol } from './Protocol.js';
 import { Deferred, generateId, wrapTryCatch } from './utils/Utils.js';
 import { isDevMode } from './utils/DevMode.js';
+import { Type } from './utils/types.js';
 
 import { debugAndPrintError, debugMatchMaking, debugMessage } from './Debug.js';
 import { RoomCache } from './matchmaker/driver/api.js';
@@ -41,6 +42,8 @@ export enum RoomInternalState {
 
 export type ExtractUserData<T> = T extends ClientArray<infer U> ? U : never;
 export type ExtractAuthData<T> = T extends ClientArray<infer _, infer U> ? U : never;
+
+export type OnCreateOptions<T extends Type<Room>> = Parameters<NonNullable<InstanceType<T>['onCreate']>>[0];
 
 /**
  * A Room class is meant to implement a game session, and/or serve as the communication channel

--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -6,7 +6,7 @@ import * as matchMaker from './MatchMaker.js';
 import { RegisteredHandler } from './matchmaker/RegisteredHandler.js';
 import { Presence } from './presence/Presence.js';
 
-import { Room } from './Room.js';
+import { OnCreateOptions, Room } from './Room.js';
 import { Type } from './utils/types.js';
 import { getBearerToken, registerGracefulShutdown } from './utils/Utils.js';
 
@@ -202,17 +202,17 @@ export class Server {
    */
   public define<T extends Type<Room>>(
     roomClass: T,
-    defaultOptions?: Parameters<NonNullable<InstanceType<T>['onCreate']>>[0],
+    defaultOptions?: OnCreateOptions<T>,
   ): RegisteredHandler
   public define<T extends Type<Room>>(
     name: string,
     roomClass: T,
-    defaultOptions?: Parameters<NonNullable<InstanceType<T>['onCreate']>>[0],
+    defaultOptions?: OnCreateOptions<T>,
   ): RegisteredHandler
   public define<T extends Type<Room>>(
     nameOrHandler: string | T,
-    handlerOrOptions: T | Parameters<NonNullable<InstanceType<T>['onCreate']>>[0],
-    defaultOptions?: Parameters<NonNullable<InstanceType<T>['onCreate']>>[0],
+    handlerOrOptions: T | OnCreateOptions<T>,
+    defaultOptions?: OnCreateOptions<T>,
   ): RegisteredHandler {
     const name = (typeof(nameOrHandler) === "string")
       ? nameOrHandler

--- a/packages/core/src/matchmaker/driver/api.ts
+++ b/packages/core/src/matchmaker/driver/api.ts
@@ -2,6 +2,9 @@ export interface SortOptions {
   [fieldName: string]: 1 | -1 | 'asc' | 'desc' | 'ascending' | 'descending';
 }
 
+export type IRoomCacheSortByKeys = 'clients' | 'maxClients';
+export type IRoomCacheFilterByKeys = 'clients' | 'maxClients' | 'processId';
+
 export function getLockId(filterOptions: any) {
   return Object.keys(filterOptions).map((key) => `${key}:${filterOptions[key]}`).join("-");
 }


### PR DESCRIPTION
This PR adds a `OnCreateOptions<Room>` utility type and improve type inference for `.sortBy()` and `.filterBy()` methods.

- Refactor the following methods to use `OnCreateOptions`:
  - `Server.define()`
  - `matchMaker.defineRoomType()`
- Refactor `RegisteredHandler`:
  - Allow type inference for `.sortBy()` based on `OnCreateOptions` + `'clients' | 'maxClients'`
  - Allow type inference for `.filterBy()` based on `OnCreateOptions` + `'clients' | 'maxClients' | 'processId'`

## Example

Based on the following `onCreate()` Room signature:
```typescript
onCreate(options: { mode: string, roomId?: string })
```

How `.filterBy()` gets auto-completed:

![image](https://github.com/user-attachments/assets/6d616cc5-be0d-4e4d-b156-f21edf8f8667)

How `.sortBy()` gets auto-completed:

![image](https://github.com/user-attachments/assets/15509a70-58dc-40fc-b234-d3a54a71b826)


It should not be a breaking change.