### PR TITLE
Make presence api always return promises

### DIFF
--- a/packages/core/src/presence/LocalPresence.ts
+++ b/packages/core/src/presence/LocalPresence.ts
@@ -12,290 +12,291 @@ type Callback = (...args: any[]) => void;
 const DEVMODE_CACHE_FILE_PATH = path.resolve(".devmode.json");
 
 export class LocalPresence implements Presence {
-    public channels = new EventEmitter();
+  public channels = new EventEmitter();
 
-    public data: {[roomName: string]: string[]} = {};
-    public hash: {[roomName: string]: {[key: string]: string}} = {};
+  public data: { [roomName: string]: string[] } = {};
+  public hash: { [roomName: string]: { [key: string]: string } } = {};
 
-    public keys: {[name: string]: string | number} = {};
+  public keys: { [name: string]: string | number } = {};
 
-    private timeouts: {[name: string]: NodeJS.Timeout} = {};
+  private timeouts: { [name: string]: NodeJS.Timeout } = {};
 
-    constructor() {
-      //
-      // reload from local cache on devMode
-      //
-      if (
-        isDevMode &&
-        fs.existsSync(DEVMODE_CACHE_FILE_PATH)
-      ) {
-        const cache = fs.readFileSync(DEVMODE_CACHE_FILE_PATH).toString('utf-8') || "{}";
-        const parsed = JSON.parse(cache);
-        if (parsed.data) { this.data = parsed.data; }
-        if (parsed.hash) { this.hash = parsed.hash; }
-        if (parsed.keys) { this.keys = parsed.keys; }
+  constructor() {
+    //
+    // reload from local cache on devMode
+    //
+    if (
+      isDevMode &&
+      fs.existsSync(DEVMODE_CACHE_FILE_PATH)
+    ) {
+      const cache = fs.readFileSync(DEVMODE_CACHE_FILE_PATH).toString('utf-8') || "{}";
+      const parsed = JSON.parse(cache);
+      if (parsed.data) { this.data = parsed.data; }
+      if (parsed.hash) { this.hash = parsed.hash; }
+      if (parsed.keys) { this.keys = parsed.keys; }
+    }
+  }
+
+  public subscribe(topic: string, callback: (...args: any[]) => void) {
+    this.channels.on(topic, callback);
+    return this;
+  }
+
+  public unsubscribe(topic: string, callback?: Callback) {
+    if (callback) {
+      this.channels.removeListener(topic, callback);
+
+    } else {
+      this.channels.removeAllListeners(topic);
+    }
+
+    return this;
+  }
+
+  public publish(topic: string, data: any) {
+    this.channels.emit(topic, data);
+    return this;
+  }
+
+  public async exists(key: string): Promise<boolean> {
+    return (
+      this.keys[key] !== undefined ||
+      this.data[key] !== undefined ||
+      this.hash[key] !== undefined
+    );
+  }
+
+  public set(key: string, value: string) {
+    this.keys[key] = value;
+  }
+
+  public setex(key: string, value: string, seconds: number) {
+    this.keys[key] = value;
+    this.expire(key, seconds);
+  }
+
+  public expire(key: string, seconds: number) {
+    // ensure previous timeout is clear before setting another one.
+    if (this.timeouts[key]) {
+      clearTimeout(this.timeouts[key]);
+    }
+    this.timeouts[key] = setTimeout(() => {
+      delete this.keys[key];
+      delete this.timeouts[key];
+    }, seconds * 1000);
+  }
+
+  public get(key: string) {
+    return this.keys[key];
+  }
+
+  public del(key: string) {
+    delete this.keys[key];
+    delete this.data[key];
+    delete this.hash[key];
+  }
+
+  public sadd(key: string, value: any) {
+    if (!this.data[key]) {
+      this.data[key] = [];
+    }
+
+    if (this.data[key].indexOf(value) === -1) {
+      this.data[key].push(value);
+    }
+  }
+
+  public async smembers(key: string): Promise<string[]> {
+    return this.data[key] || [];
+  }
+
+  public async sismember(key: string, field: string) {
+    return this.data[key] && this.data[key].includes(field) ? 1 : 0;
+  }
+
+  public srem(key: string, value: any) {
+    if (this.data[key]) {
+      spliceOne(this.data[key], this.data[key].indexOf(value));
+    }
+  }
+
+  public scard(key: string) {
+    return (this.data[key] || []).length;
+  }
+
+  public async sinter(...keys: string[]) {
+    const intersection: { [value: string]: number } = {};
+
+    for (let i = 0, l = keys.length; i < l; i++) {
+      (await this.smembers(keys[i])).forEach((member) => {
+        if (!intersection[member]) {
+          intersection[member] = 0;
+        }
+
+        intersection[member]++;
+      });
+    }
+
+    return Object.keys(intersection).reduce((prev, curr) => {
+      if (intersection[curr] > 1) {
+        prev.push(curr);
+      }
+      return prev;
+    }, []);
+  }
+
+  public hset(key: string, field: string, value: string) {
+    if (!this.hash[key]) { this.hash[key] = {}; }
+    this.hash[key][field] = value;
+    return Promise.resolve();
+  }
+
+  public hincrby(key: string, field: string, incrBy: number) {
+    if (!this.hash[key]) { this.hash[key] = {}; }
+    let value = Number(this.hash[key][field] || '0');
+    value += incrBy;
+    this.hash[key][field] = value.toString();
+    return Promise.resolve(value);
+  }
+
+  public hincrbyex(key: string, field: string, incrBy: number, expireInSeconds: number) {
+    if (!this.hash[key]) { this.hash[key] = {}; }
+    let value = Number(this.hash[key][field] || '0');
+    value += incrBy;
+    this.hash[key][field] = value.toString();
+    this.setex(key, field, expireInSeconds);
+    return Promise.resolve(value);
+  }
+
+  public async hget(key: string, field: string) {
+    return this.hash[key] && this.hash[key][field];
+  }
+
+  public async hgetall(key: string) {
+    return this.hash[key] || {};
+  }
+
+  public hdel(key: string, field: any) {
+    const success = this.hash?.[key]?.[field] !== undefined;
+    if (success) {
+      delete this.hash[key][field];
+    }
+    return Promise.resolve(success);
+  }
+
+  public async hlen(key: string) {
+    return this.hash[key] && Object.keys(this.hash[key]).length || 0;
+  }
+
+  public async incr(key: string) {
+    if (!this.keys[key]) {
+      this.keys[key] = 0;
+    }
+    (this.keys[key] as number)++;
+    return Promise.resolve(this.keys[key] as number);
+  }
+
+  public async decr(key: string) {
+    if (!this.keys[key]) {
+      this.keys[key] = 0;
+    }
+    (this.keys[key] as number)--;
+    return Promise.resolve(this.keys[key] as number);
+  }
+
+  public llen(key: string): number {
+    return (this.data[key] && this.data[key].length) || 0;
+  }
+
+  public rpush(key: string, ...values: string[]): number {
+    if (!this.data[key]) { this.data[key] = []; }
+
+    let lastLength: number = 0;
+
+    values.forEach(value => {
+      lastLength = this.data[key].push(value);
+    });
+
+    return lastLength;
+  }
+
+  public lpush(key: string, ...values: string[]): number {
+    if (!this.data[key]) { this.data[key] = []; }
+
+    let lastLength: number = 0;
+
+    values.forEach(value => {
+      lastLength = this.data[key].unshift(value);
+    });
+
+    return lastLength;
+  }
+
+
+  public lpop(key: string): string {
+    return Array.isArray(this.data[key]) && this.data[key].shift();
+  }
+
+  public rpop(key: string): string {
+    return this.data[key].pop();
+  }
+
+  public brpop(...args: [...keys: string[], timeoutInSeconds: number]): Promise<[string, string] | null> {
+    const keys = args.slice(0, -2) as string[];
+    const timeoutInSeconds = args[args.length - 1] as number;
+
+    const getFirstPopulated = (): [string, string] | null => {
+      const keyWithValue = keys.find(key => this.data[key] && this.data[key].length > 0);
+      if (keyWithValue) {
+        return [keyWithValue, this.data[keyWithValue].pop()];
+      } else {
+        return null;
       }
     }
 
-    public subscribe(topic: string, callback: (...args: any[]) => void) {
-        this.channels.on(topic, callback);
-        return this;
-    }
+    const firstPopulated = getFirstPopulated();
 
-    public unsubscribe(topic: string, callback?: Callback) {
-        if (callback)  {
-            this.channels.removeListener(topic, callback);
+    if (firstPopulated) {
+      // return first populated key + item
+      return Promise.resolve(firstPopulated);
 
-        } else {
-            this.channels.removeAllListeners(topic);
-        }
+    } else {
+      // 8 retries per second
+      const maxRetries = timeoutInSeconds * 8;
 
-        return this;
-    }
+      let tries = 0;
+      return new Promise((resolve) => {
+        const interval = setInterval(() => {
+          tries++;
 
-    public publish(topic: string, data: any) {
-        this.channels.emit(topic, data);
-        return this;
-    }
+          const firstPopulated = getFirstPopulated();
+          if (firstPopulated) {
+            clearInterval(interval);
+            return resolve(firstPopulated);
 
-    public async exists(key: string): Promise<boolean> {
-        return (
-          this.keys[key] !== undefined ||
-          this.data[key] !== undefined ||
-          this.hash[key] !== undefined
-        );
-    }
-
-    public set(key: string, value: string) {
-        this.keys[key] = value;
-    }
-
-    public setex(key: string, value: string, seconds: number) {
-        this.keys[key] = value;
-        this.expire(key, seconds);
-    }
-
-    public expire(key: string, seconds: number) {
-        // ensure previous timeout is clear before setting another one.
-        if (this.timeouts[key]) {
-            clearTimeout(this.timeouts[key]);
-        }
-        this.timeouts[key] = setTimeout(() => {
-            delete this.keys[key];
-            delete this.timeouts[key];
-        }, seconds * 1000);
-    }
-
-    public get(key: string) {
-        return this.keys[key];
-    }
-
-    public del(key: string) {
-        delete this.keys[key];
-        delete this.data[key];
-        delete this.hash[key];
-    }
-
-    public sadd(key: string, value: any) {
-        if (!this.data[key]) {
-            this.data[key] = [];
-        }
-
-        if (this.data[key].indexOf(value) === -1) {
-            this.data[key].push(value);
-        }
-    }
-
-    public async smembers(key: string): Promise<string[]> {
-        return this.data[key] || [];
-    }
-
-    public async sismember(key: string, field: string) {
-        return this.data[key] && this.data[key].includes(field) ? 1 : 0;
-    }
-
-    public srem(key: string, value: any) {
-        if (this.data[key]) {
-            spliceOne(this.data[key], this.data[key].indexOf(value));
-        }
-    }
-
-    public scard(key: string) {
-        return (this.data[key] || []).length;
-    }
-
-    public async sinter(...keys: string[]) {
-      const intersection: {[value: string]: number} = {};
-
-      for (let i = 0, l = keys.length; i < l; i++) {
-        (await this.smembers(keys[i])).forEach((member) => {
-          if (!intersection[member]) {
-            intersection[member] = 0;
+          } else if (tries >= maxRetries) {
+            clearInterval(interval);
+            return resolve(undefined);
           }
 
-          intersection[member]++;
-        });
-      }
-
-      return Object.keys(intersection).reduce((prev, curr) => {
-        if (intersection[curr] > 1) {
-          prev.push(curr);
-        }
-        return prev;
-      }, []);
-    }
-
-    public hset(key: string, field: string, value: string) {
-        if (!this.hash[key]) { this.hash[key] = {}; }
-        this.hash[key][field] = value;
-    }
-
-    public hincrby(key: string, field: string, incrBy: number) {
-        if (!this.hash[key]) { this.hash[key] = {}; }
-        let value = Number(this.hash[key][field] || '0');
-        value += incrBy;
-        this.hash[key][field] = value.toString();
-        return value;
-    }
-
-    public hincrbyex(key: string, field: string, incrBy: number, expireInSeconds: number) {
-        if (!this.hash[key]) { this.hash[key] = {}; }
-        let value = Number(this.hash[key][field] || '0');
-        value += incrBy;
-        this.hash[key][field] = value.toString();
-        this.setex(key, field, expireInSeconds);
-        return value;
-    }
-
-    public async hget(key: string, field: string) {
-        return this.hash[key] && this.hash[key][field];
-    }
-
-    public async hgetall(key: string) {
-        return this.hash[key] || {};
-    }
-
-    public hdel(key: string, field: any) {
-        const success = this.hash?.[key]?.[field] !== undefined;
-        if (success) {
-            delete this.hash[key][field];
-        }
-        return success;
-    }
-
-    public async hlen(key: string) {
-        return this.hash[key] && Object.keys(this.hash[key]).length || 0;
-    }
-
-    public async incr(key: string) {
-        if (!this.keys[key]) {
-            this.keys[key] = 0;
-        }
-        (this.keys[key] as number)++;
-        return Promise.resolve(this.keys[key] as number);
-    }
-
-    public async decr(key: string) {
-        if (!this.keys[key]) {
-            this.keys[key] = 0;
-        }
-        (this.keys[key] as number)--;
-        return Promise.resolve(this.keys[key] as number);
-    }
-
-    public llen(key: string): number {
-      return (this.data[key] && this.data[key].length) || 0;
-    }
-
-    public rpush(key: string, ...values: string[]): number {
-      if (!this.data[key]) { this.data[key] = []; }
-
-      let lastLength: number = 0;
-
-      values.forEach(value => {
-        lastLength = this.data[key].push(value);
+        }, (timeoutInSeconds * 1000) / maxRetries);
       });
-
-      return lastLength;
     }
+  }
 
-    public lpush(key: string, ...values: string[]): number {
-      if (!this.data[key]) { this.data[key] = []; }
+  public setMaxListeners(number: number) {
+    this.channels.setMaxListeners(number);
+  }
 
-      let lastLength: number = 0;
-
-      values.forEach(value => {
-        lastLength = this.data[key].unshift(value);
+  public shutdown() {
+    if (isDevMode) {
+      const cache = JSON.stringify({
+        data: this.data,
+        hash: this.hash,
+        keys: this.keys
       });
-
-      return lastLength;
+      fs.writeFileSync(DEVMODE_CACHE_FILE_PATH, cache, { encoding: "utf-8" });
     }
-
-
-    public lpop(key: string): string {
-      return Array.isArray(this.data[key]) && this.data[key].shift();
-    }
-
-    public rpop(key: string): string {
-      return this.data[key].pop();
-    }
-
-    public brpop(...args: [...keys: string[], timeoutInSeconds: number]): Promise<[string, string] | null> {
-      const keys = args.slice(0, -2) as string[];
-      const timeoutInSeconds = args[args.length - 1] as number;
-
-      const getFirstPopulated = (): [string, string] | null => {
-        const keyWithValue = keys.find(key => this.data[key] && this.data[key].length > 0);
-        if (keyWithValue) {
-          return [keyWithValue, this.data[keyWithValue].pop()];
-        } else {
-          return null;
-        }
-      }
-
-      const firstPopulated = getFirstPopulated();
-
-      if (firstPopulated) {
-        // return first populated key + item
-        return Promise.resolve(firstPopulated);
-
-      } else {
-        // 8 retries per second
-        const maxRetries = timeoutInSeconds * 8;
-
-        let tries = 0;
-        return new Promise((resolve) => {
-          const interval = setInterval(() => {
-            tries++;
-
-            const firstPopulated = getFirstPopulated();
-            if (firstPopulated) {
-              clearInterval(interval);
-              return resolve(firstPopulated);
-
-            } else if (tries >= maxRetries) {
-              clearInterval(interval);
-              return resolve(undefined);
-            }
-
-          }, (timeoutInSeconds * 1000) / maxRetries);
-        });
-      }
-    }
-
-    public setMaxListeners(number: number) {
-      this.channels.setMaxListeners(number);
-    }
-
-    public shutdown() {
-      if (isDevMode) {
-        const cache = JSON.stringify({
-          data: this.data,
-          hash: this.hash,
-          keys: this.keys
-        });
-        fs.writeFileSync(DEVMODE_CACHE_FILE_PATH, cache, { encoding: "utf-8" });
-      }
-    }
+  }
 
 }

--- a/packages/core/src/presence/LocalPresence.ts
+++ b/packages/core/src/presence/LocalPresence.ts
@@ -12,291 +12,291 @@ type Callback = (...args: any[]) => void;
 const DEVMODE_CACHE_FILE_PATH = path.resolve(".devmode.json");
 
 export class LocalPresence implements Presence {
-  public channels = new EventEmitter();
+    public channels = new EventEmitter();
 
-  public data: { [roomName: string]: string[] } = {};
-  public hash: { [roomName: string]: { [key: string]: string } } = {};
+    public data: {[roomName: string]: string[]} = {};
+    public hash: {[roomName: string]: {[key: string]: string}} = {};
 
-  public keys: { [name: string]: string | number } = {};
+    public keys: {[name: string]: string | number} = {};
 
-  private timeouts: { [name: string]: NodeJS.Timeout } = {};
+    private timeouts: {[name: string]: NodeJS.Timeout} = {};
 
-  constructor() {
-    //
-    // reload from local cache on devMode
-    //
-    if (
-      isDevMode &&
-      fs.existsSync(DEVMODE_CACHE_FILE_PATH)
-    ) {
-      const cache = fs.readFileSync(DEVMODE_CACHE_FILE_PATH).toString('utf-8') || "{}";
-      const parsed = JSON.parse(cache);
-      if (parsed.data) { this.data = parsed.data; }
-      if (parsed.hash) { this.hash = parsed.hash; }
-      if (parsed.keys) { this.keys = parsed.keys; }
-    }
-  }
-
-  public subscribe(topic: string, callback: (...args: any[]) => void) {
-    this.channels.on(topic, callback);
-    return this;
-  }
-
-  public unsubscribe(topic: string, callback?: Callback) {
-    if (callback) {
-      this.channels.removeListener(topic, callback);
-
-    } else {
-      this.channels.removeAllListeners(topic);
+    constructor() {
+      //
+      // reload from local cache on devMode
+      //
+      if (
+        isDevMode &&
+        fs.existsSync(DEVMODE_CACHE_FILE_PATH)
+      ) {
+        const cache = fs.readFileSync(DEVMODE_CACHE_FILE_PATH).toString('utf-8') || "{}";
+        const parsed = JSON.parse(cache);
+        if (parsed.data) { this.data = parsed.data; }
+        if (parsed.hash) { this.hash = parsed.hash; }
+        if (parsed.keys) { this.keys = parsed.keys; }
+      }
     }
 
-    return this;
-  }
-
-  public publish(topic: string, data: any) {
-    this.channels.emit(topic, data);
-    return this;
-  }
-
-  public async exists(key: string): Promise<boolean> {
-    return (
-      this.keys[key] !== undefined ||
-      this.data[key] !== undefined ||
-      this.hash[key] !== undefined
-    );
-  }
-
-  public set(key: string, value: string) {
-    this.keys[key] = value;
-  }
-
-  public setex(key: string, value: string, seconds: number) {
-    this.keys[key] = value;
-    this.expire(key, seconds);
-  }
-
-  public expire(key: string, seconds: number) {
-    // ensure previous timeout is clear before setting another one.
-    if (this.timeouts[key]) {
-      clearTimeout(this.timeouts[key]);
-    }
-    this.timeouts[key] = setTimeout(() => {
-      delete this.keys[key];
-      delete this.timeouts[key];
-    }, seconds * 1000);
-  }
-
-  public get(key: string) {
-    return this.keys[key];
-  }
-
-  public del(key: string) {
-    delete this.keys[key];
-    delete this.data[key];
-    delete this.hash[key];
-  }
-
-  public sadd(key: string, value: any) {
-    if (!this.data[key]) {
-      this.data[key] = [];
+    public subscribe(topic: string, callback: (...args: any[]) => void) {
+        this.channels.on(topic, callback);
+        return this;
     }
 
-    if (this.data[key].indexOf(value) === -1) {
-      this.data[key].push(value);
-    }
-  }
+    public unsubscribe(topic: string, callback?: Callback) {
+        if (callback)  {
+            this.channels.removeListener(topic, callback);
 
-  public async smembers(key: string): Promise<string[]> {
-    return this.data[key] || [];
-  }
-
-  public async sismember(key: string, field: string) {
-    return this.data[key] && this.data[key].includes(field) ? 1 : 0;
-  }
-
-  public srem(key: string, value: any) {
-    if (this.data[key]) {
-      spliceOne(this.data[key], this.data[key].indexOf(value));
-    }
-  }
-
-  public scard(key: string) {
-    return (this.data[key] || []).length;
-  }
-
-  public async sinter(...keys: string[]) {
-    const intersection: { [value: string]: number } = {};
-
-    for (let i = 0, l = keys.length; i < l; i++) {
-      (await this.smembers(keys[i])).forEach((member) => {
-        if (!intersection[member]) {
-          intersection[member] = 0;
+        } else {
+            this.channels.removeAllListeners(topic);
         }
 
-        intersection[member]++;
-      });
+        return this;
     }
 
-    return Object.keys(intersection).reduce((prev, curr) => {
-      if (intersection[curr] > 1) {
-        prev.push(curr);
-      }
-      return prev;
-    }, []);
-  }
-
-  public hset(key: string, field: string, value: string) {
-    if (!this.hash[key]) { this.hash[key] = {}; }
-    this.hash[key][field] = value;
-    return Promise.resolve();
-  }
-
-  public hincrby(key: string, field: string, incrBy: number) {
-    if (!this.hash[key]) { this.hash[key] = {}; }
-    let value = Number(this.hash[key][field] || '0');
-    value += incrBy;
-    this.hash[key][field] = value.toString();
-    return Promise.resolve(value);
-  }
-
-  public hincrbyex(key: string, field: string, incrBy: number, expireInSeconds: number) {
-    if (!this.hash[key]) { this.hash[key] = {}; }
-    let value = Number(this.hash[key][field] || '0');
-    value += incrBy;
-    this.hash[key][field] = value.toString();
-    this.setex(key, field, expireInSeconds);
-    return Promise.resolve(value);
-  }
-
-  public async hget(key: string, field: string) {
-    return this.hash[key] && this.hash[key][field];
-  }
-
-  public async hgetall(key: string) {
-    return this.hash[key] || {};
-  }
-
-  public hdel(key: string, field: any) {
-    const success = this.hash?.[key]?.[field] !== undefined;
-    if (success) {
-      delete this.hash[key][field];
-    }
-    return Promise.resolve(success);
-  }
-
-  public async hlen(key: string) {
-    return this.hash[key] && Object.keys(this.hash[key]).length || 0;
-  }
-
-  public async incr(key: string) {
-    if (!this.keys[key]) {
-      this.keys[key] = 0;
-    }
-    (this.keys[key] as number)++;
-    return Promise.resolve(this.keys[key] as number);
-  }
-
-  public async decr(key: string) {
-    if (!this.keys[key]) {
-      this.keys[key] = 0;
-    }
-    (this.keys[key] as number)--;
-    return Promise.resolve(this.keys[key] as number);
-  }
-
-  public llen(key: string): number {
-    return (this.data[key] && this.data[key].length) || 0;
-  }
-
-  public rpush(key: string, ...values: string[]): number {
-    if (!this.data[key]) { this.data[key] = []; }
-
-    let lastLength: number = 0;
-
-    values.forEach(value => {
-      lastLength = this.data[key].push(value);
-    });
-
-    return lastLength;
-  }
-
-  public lpush(key: string, ...values: string[]): number {
-    if (!this.data[key]) { this.data[key] = []; }
-
-    let lastLength: number = 0;
-
-    values.forEach(value => {
-      lastLength = this.data[key].unshift(value);
-    });
-
-    return lastLength;
-  }
-
-
-  public lpop(key: string): string {
-    return Array.isArray(this.data[key]) && this.data[key].shift();
-  }
-
-  public rpop(key: string): string {
-    return this.data[key].pop();
-  }
-
-  public brpop(...args: [...keys: string[], timeoutInSeconds: number]): Promise<[string, string] | null> {
-    const keys = args.slice(0, -2) as string[];
-    const timeoutInSeconds = args[args.length - 1] as number;
-
-    const getFirstPopulated = (): [string, string] | null => {
-      const keyWithValue = keys.find(key => this.data[key] && this.data[key].length > 0);
-      if (keyWithValue) {
-        return [keyWithValue, this.data[keyWithValue].pop()];
-      } else {
-        return null;
-      }
+    public publish(topic: string, data: any) {
+        this.channels.emit(topic, data);
+        return this;
     }
 
-    const firstPopulated = getFirstPopulated();
+    public async exists(key: string): Promise<boolean> {
+        return (
+          this.keys[key] !== undefined ||
+          this.data[key] !== undefined ||
+          this.hash[key] !== undefined
+        );
+    }
 
-    if (firstPopulated) {
-      // return first populated key + item
-      return Promise.resolve(firstPopulated);
+    public set(key: string, value: string) {
+        this.keys[key] = value;
+    }
 
-    } else {
-      // 8 retries per second
-      const maxRetries = timeoutInSeconds * 8;
+    public setex(key: string, value: string, seconds: number) {
+        this.keys[key] = value;
+        this.expire(key, seconds);
+    }
 
-      let tries = 0;
-      return new Promise((resolve) => {
-        const interval = setInterval(() => {
-          tries++;
+    public expire(key: string, seconds: number) {
+        // ensure previous timeout is clear before setting another one.
+        if (this.timeouts[key]) {
+            clearTimeout(this.timeouts[key]);
+        }
+        this.timeouts[key] = setTimeout(() => {
+            delete this.keys[key];
+            delete this.timeouts[key];
+        }, seconds * 1000);
+    }
 
-          const firstPopulated = getFirstPopulated();
-          if (firstPopulated) {
-            clearInterval(interval);
-            return resolve(firstPopulated);
+    public get(key: string) {
+        return this.keys[key];
+    }
 
-          } else if (tries >= maxRetries) {
-            clearInterval(interval);
-            return resolve(undefined);
+    public del(key: string) {
+        delete this.keys[key];
+        delete this.data[key];
+        delete this.hash[key];
+    }
+
+    public sadd(key: string, value: any) {
+        if (!this.data[key]) {
+            this.data[key] = [];
+        }
+
+        if (this.data[key].indexOf(value) === -1) {
+            this.data[key].push(value);
+        }
+    }
+
+    public async smembers(key: string): Promise<string[]> {
+        return this.data[key] || [];
+    }
+
+    public async sismember(key: string, field: string) {
+        return this.data[key] && this.data[key].includes(field) ? 1 : 0;
+    }
+
+    public srem(key: string, value: any) {
+        if (this.data[key]) {
+            spliceOne(this.data[key], this.data[key].indexOf(value));
+        }
+    }
+
+    public scard(key: string) {
+        return (this.data[key] || []).length;
+    }
+
+    public async sinter(...keys: string[]) {
+      const intersection: {[value: string]: number} = {};
+
+      for (let i = 0, l = keys.length; i < l; i++) {
+        (await this.smembers(keys[i])).forEach((member) => {
+          if (!intersection[member]) {
+            intersection[member] = 0;
           }
 
-        }, (timeoutInSeconds * 1000) / maxRetries);
-      });
-    }
-  }
+          intersection[member]++;
+        });
+      }
 
-  public setMaxListeners(number: number) {
-    this.channels.setMaxListeners(number);
-  }
-
-  public shutdown() {
-    if (isDevMode) {
-      const cache = JSON.stringify({
-        data: this.data,
-        hash: this.hash,
-        keys: this.keys
-      });
-      fs.writeFileSync(DEVMODE_CACHE_FILE_PATH, cache, { encoding: "utf-8" });
+      return Object.keys(intersection).reduce((prev, curr) => {
+        if (intersection[curr] > 1) {
+          prev.push(curr);
+        }
+        return prev;
+      }, []);
     }
-  }
+
+    public hset(key: string, field: string, value: string) {
+        if (!this.hash[key]) { this.hash[key] = {}; }
+        this.hash[key][field] = value;
+        return Promise.resolve();
+    }
+
+    public hincrby(key: string, field: string, incrBy: number) {
+        if (!this.hash[key]) { this.hash[key] = {}; }
+        let value = Number(this.hash[key][field] || '0');
+        value += incrBy;
+        this.hash[key][field] = value.toString();
+        return Promise.resolve(value);
+    }
+
+    public hincrbyex(key: string, field: string, incrBy: number, expireInSeconds: number) {
+        if (!this.hash[key]) { this.hash[key] = {}; }
+        let value = Number(this.hash[key][field] || '0');
+        value += incrBy;
+        this.hash[key][field] = value.toString();
+        this.setex(key, field, expireInSeconds);
+        return Promise.resolve(value);
+    }
+
+    public async hget(key: string, field: string) {
+        return this.hash[key] && this.hash[key][field];
+    }
+
+    public async hgetall(key: string) {
+        return this.hash[key] || {};
+    }
+
+    public hdel(key: string, field: any) {
+        const success = this.hash?.[key]?.[field] !== undefined;
+        if (success) {
+            delete this.hash[key][field];
+        }
+        return Promise.resolve(success);
+    }
+
+    public async hlen(key: string) {
+        return this.hash[key] && Object.keys(this.hash[key]).length || 0;
+    }
+
+    public async incr(key: string) {
+        if (!this.keys[key]) {
+            this.keys[key] = 0;
+        }
+        (this.keys[key] as number)++;
+        return Promise.resolve(this.keys[key] as number);
+    }
+
+    public async decr(key: string) {
+        if (!this.keys[key]) {
+            this.keys[key] = 0;
+        }
+        (this.keys[key] as number)--;
+        return Promise.resolve(this.keys[key] as number);
+    }
+
+    public llen(key: string): number {
+      return (this.data[key] && this.data[key].length) || 0;
+    }
+
+    public rpush(key: string, ...values: string[]): number {
+      if (!this.data[key]) { this.data[key] = []; }
+
+      let lastLength: number = 0;
+
+      values.forEach(value => {
+        lastLength = this.data[key].push(value);
+      });
+
+      return lastLength;
+    }
+
+    public lpush(key: string, ...values: string[]): number {
+      if (!this.data[key]) { this.data[key] = []; }
+
+      let lastLength: number = 0;
+
+      values.forEach(value => {
+        lastLength = this.data[key].unshift(value);
+      });
+
+      return lastLength;
+    }
+
+
+    public lpop(key: string): string {
+      return Array.isArray(this.data[key]) && this.data[key].shift();
+    }
+
+    public rpop(key: string): string {
+      return this.data[key].pop();
+    }
+
+    public brpop(...args: [...keys: string[], timeoutInSeconds: number]): Promise<[string, string] | null> {
+      const keys = args.slice(0, -2) as string[];
+      const timeoutInSeconds = args[args.length - 1] as number;
+
+      const getFirstPopulated = (): [string, string] | null => {
+        const keyWithValue = keys.find(key => this.data[key] && this.data[key].length > 0);
+        if (keyWithValue) {
+          return [keyWithValue, this.data[keyWithValue].pop()];
+        } else {
+          return null;
+        }
+      }
+
+      const firstPopulated = getFirstPopulated();
+
+      if (firstPopulated) {
+        // return first populated key + item
+        return Promise.resolve(firstPopulated);
+
+      } else {
+        // 8 retries per second
+        const maxRetries = timeoutInSeconds * 8;
+
+        let tries = 0;
+        return new Promise((resolve) => {
+          const interval = setInterval(() => {
+            tries++;
+
+            const firstPopulated = getFirstPopulated();
+            if (firstPopulated) {
+              clearInterval(interval);
+              return resolve(firstPopulated);
+
+            } else if (tries >= maxRetries) {
+              clearInterval(interval);
+              return resolve(undefined);
+            }
+
+          }, (timeoutInSeconds * 1000) / maxRetries);
+        });
+      }
+    }
+
+    public setMaxListeners(number: number) {
+      this.channels.setMaxListeners(number);
+    }
+
+    public shutdown() {
+      if (isDevMode) {
+        const cache = JSON.stringify({
+          data: this.data,
+          hash: this.hash,
+          keys: this.keys
+        });
+        fs.writeFileSync(DEVMODE_CACHE_FILE_PATH, cache, { encoding: "utf-8" });
+      }
+    }
 
 }

--- a/packages/core/src/presence/Presence.ts
+++ b/packages/core/src/presence/Presence.ts
@@ -134,19 +134,19 @@ export interface Presence {
      * Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created.
      * If field already exists in the hash, it is overwritten.
      */
-    hset(key: string, field: string, value: string);
+    hset(key: string, field: string, value: string): Promise<void>;
 
     /**
      * Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key
      * holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
      */
-    hincrby(key: string, field: string, value: number): number | Promise<number>;
+    hincrby(key: string, field: string, value: number): Promise<number>;
 
     /**
      * WARNING: DO NOT USE THIS METHOD. It is meant for internal use only.
      * @private
      */
-    hincrbyex(key: string, field: string, value: number, expireInSeconds: number): number | Promise<number>;
+    hincrbyex(key: string, field: string, value: number, expireInSeconds: number): Promise<number>;
 
     /**
      * Returns the value associated with field in the hash stored at key.
@@ -162,7 +162,7 @@ export interface Presence {
      * Removes the specified fields from the hash stored at key. Specified fields that do not exist within
      * this hash are ignored. If key does not exist, it is treated as an empty hash and this command returns 0.
      */
-    hdel(key: string, field: string): boolean | Promise<boolean>;
+    hdel(key: string, field: string): Promise<boolean>;
 
     /**
      * Returns the number of fields contained in the hash stored at key


### PR DESCRIPTION
Currently Presence API are a mix of asynchronous and synchronous calls depending if you use LocalPresence or RedisPresence.

Some functions like `hset` also do not have any typed return signature. This has been a footgun for me because it can lead to race conditions not spotted by the TypeScript compiler:

```
// missing await keyword is not reported as an error
// this works locally with LocalPresence, but fails on production silently with RedisPresence
for (const bot of botsData) {
       matchMaker.presence.hset("bots", bot.id, JSON.stringify(bot))
}
```

I propose to make the Presence API functions signature safer by restricting them to asynchronous functions only, that always return promises. This force the user to use the "await" keyword, and make sure they avoid any asynchronous / race condition trap.

The LocalPresence functions have been changed to return a synchronous value with Promise.resolve. This adds a microtask which is an insignificant performance loss, and ensure the behavior of the logic will remain the same when switching from LocalPresence to RedisPresence