### PR TITLE
@colyseus/tools: do NOT include express.json() body parser by default

### DIFF
--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/tools",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "description": "Simplify the development and production settings for your Colyseus project.",
   "input": "./src/index.ts",
   "main": "./build/index.js",

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -199,9 +199,6 @@ export async function getTransport(options: ConfigOptions) {
       // Enable CORS
       app.use(cors({ origin: true, credentials: true, }));
 
-      // Enable JSON parsing.
-      app.use(express.json());
-
       if (options.initializeExpress) {
           await options.initializeExpress(app);
       }


### PR DESCRIPTION
When using `@colyseus/tools`, the body parser used to be included behind all routes by default.

This was not ideal for 2 reasons: 
- It was not possible to customize the max. allowed payload body limit, e.g. `express.json({ limit: "5kb" })` (see: https://github.com/colyseus/colyseus/pull/774)
- Some 3rd party libraries do not work properly if using `express.json()` before registering them (e.g. [better-auth](https://www.better-auth.com/docs/integrations/express#mount-the-handler))

If you rely on this behaviour, you can add the `express.json()` parser yourself in your `initializeExpress()` method:

```typescript
// src/app.config.ts
// ...
export default config({

  initializeExpress: (app) => {
    app.use(express.json());

    // ...
  }
});
```