### PR TITLE
Game center auth support added. Issue #884

### DIFF
--- a/packages/auth/src/GameCenter.ts
+++ b/packages/auth/src/GameCenter.ts
@@ -1,0 +1,81 @@
+import { createPublicKey, createVerify } from 'crypto';
+import { URL } from 'url';
+
+export interface GameCenterCredentials {
+  playerId: string;
+  bundleId: string;
+  timestamp: number;
+  salt: string;
+  signature: string;
+  publicKeyUrl: string;
+}
+
+const publicKeyCache = new Map<string, string>();
+
+async function fetchPublicKey(publicKeyUrl: string): Promise<string> {
+  const cached = publicKeyCache.get(publicKeyUrl);
+  if (cached) {
+    return cached;
+  }
+
+  const url = new URL(publicKeyUrl);
+  if (url.protocol !== 'https:' ||
+    (!url.hostname.endsWith('.apple.com') && url.hostname !== 'apple.com')) {
+    throw new Error("Invalid public key URL domain");
+  }
+
+  const certResponse = await fetch(publicKeyUrl);
+  if (!certResponse.ok) {
+    throw new Error("Failed to fetch public key");
+  }
+  const certData = await certResponse.arrayBuffer();
+  const base64Cert = Buffer.from(certData).toString('base64');
+  
+  // Convert to PEM format
+  const pemCert = `-----BEGIN CERTIFICATE-----\n${base64Cert.match(/.{1,64}/g)?.join('\n')}\n-----END CERTIFICATE-----`;
+  
+  publicKeyCache.set(publicKeyUrl, pemCert);
+  return pemCert;
+}
+
+export async function authenticateGameCenter(credentials: GameCenterCredentials): Promise<{ playerId: string; bundleId: string }> {
+  const { playerId, bundleId, timestamp, salt, signature, publicKeyUrl } = credentials;
+
+  if (!playerId) throw new Error("Player ID required");
+  if (!bundleId) throw new Error("Bundle ID required");
+  if (!timestamp) throw new Error("Timestamp required");
+  if (!salt) throw new Error("Salt required");
+  if (!signature) throw new Error("Signature required");
+  if (!publicKeyUrl) throw new Error("Public key URL required");
+
+  const pemCert = await fetchPublicKey(publicKeyUrl);
+
+  // Convert timestamp to big-endian 8-byte buffer (like Node.js example)
+  // Apple Game Center timestamps are in milliseconds, but we need to use them as-is
+  const timestampBuffer = Buffer.alloc(8);
+  const high = Math.floor(timestamp / 0x100000000);
+  const low = timestamp % 0x100000000;
+  timestampBuffer.writeUInt32BE(high, 0);
+  timestampBuffer.writeUInt32BE(low, 4);
+
+  const verify = createVerify('sha256');
+  verify.update(playerId, 'utf8');
+  verify.update(bundleId, 'utf8');
+  verify.update(timestampBuffer);
+  verify.update(salt, 'base64');
+  verify.end();
+
+  const signatureBuffer = Buffer.from(signature, 'base64');
+  const isValid = verify.verify(pemCert, signatureBuffer);
+
+  if (!isValid) {
+    throw new Error("Invalid signature");
+  }
+
+  const timestampAge = Date.now() - (timestamp * 1000);
+  if (timestampAge > 600000) {
+    throw new Error("Timestamp expired");
+  }
+
+  return { playerId, bundleId };
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,10 +1,11 @@
 import { Request } from 'express-jwt';
 
 import { JWT, JwtPayload, Jwt } from './JWT.js';
-import { auth, AuthSettings, RegisterWithEmailAndPasswordCallback, FindUserByEmailCallback, ParseTokenCallback, GenerateTokenCallback, HashPasswordCallback,} from './auth.js';
+import { auth, AuthSettings, RegisterWithEmailAndPasswordCallback, FindUserByEmailCallback, ParseTokenCallback, GenerateTokenCallback, HashPasswordCallback, GameCenterAuthData, GameCenterAuthCallback } from './auth.js';
 
 import { OAuthProviderCallback } from './oauth.js';
 import { Hash } from './Hash.js';
+import { authenticateGameCenter, GameCenterCredentials } from './GameCenter.js';
 
 export type {
   Request, JwtPayload, Jwt,
@@ -17,6 +18,9 @@ export type {
   HashPasswordCallback,
 
   OAuthProviderCallback,
+  GameCenterAuthData,
+  GameCenterAuthCallback,
+  GameCenterCredentials,
 };
 
-export { Hash, JWT, auth, };
+export { Hash, JWT, auth, authenticateGameCenter };

--- a/packages/auth/test/GameCenter.test.ts
+++ b/packages/auth/test/GameCenter.test.ts
@@ -1,0 +1,110 @@
+import assert from "assert";
+import http from "http";
+import * as httpie from "httpie";
+import { JWT, auth, authenticateGameCenter } from "../src/index";
+import express from "express";
+
+const TEST_PORT = 8889;
+
+function get(segments: string, opts: Partial<httpie.Options> = undefined) {
+  return httpie.get(`http://localhost:${TEST_PORT}${segments}`, opts);
+}
+function post(segments: string, opts: Partial<httpie.Options> = undefined) {
+  return httpie.post(`http://localhost:${TEST_PORT}${segments}`, opts);
+}
+
+// JWT Secret for testing
+JWT.settings.secret = "@%^&";
+
+// Integration test token taken from: https://github.com/maeltm/node-gamecenter-identity-verifier/blob/master/test/integrationTest.js
+// Real token used to check caching behavior - sharing has no security consequences
+const testToken = {
+  playerId: 'G:1965586982',
+  publicKeyUrl: 'https://static.gc.apple.com/public-key/gc-prod-4.cer',
+  timestamp: 1565257031287,
+  signature: 'uqLBTr9Uex8zCpc1UQ1MIDMitb+HUat2Mah4Kw6AVLSGe0gGNJXlih2i5X+0Z' +
+    'wVY0S9zY2NHWi2gFjmhjt/4kxWGMkupqXX5H/qhE2m7hzox6lZJpH98ZEUbouWRfZX2ZhU' +
+    'lCkAX09oRNi7fI7mWL1/o88MaI/y6k6tLr14JTzmlxgdyhw+QRLxRPA6NuvUlRSJpyJ4aG' +
+    'tNH5/wHdKQWL8nUnFYiYmaY8R7IjzNxPfy8UJTUWmeZvMSgND4u8EjADPsz7ZtZyWAPi8kY' +
+    'cAb6M8k0jwLD3vrYCB8XXyO2RQb/FY2TM4zJuI7PzLlvvgOJXbbfVtHx7Evnm5NYoyzgzw==',
+  salt: 'DzqqrQ==',
+  bundleId: 'cloud.xtralife.gamecenterauth'
+};
+
+describe("Game Center Auth", () => {
+  let app: ReturnType<typeof express>;
+  let server: http.Server;
+  let fakeUsers: any = {};
+
+  beforeEach(async () => {
+    app = express();
+    app.use(auth.prefix, auth.routes({
+      onGameCenterAuth: async (authData) => {
+        // Mock user creation/retrieval
+        const user = {
+          id: 123,
+          playerId: authData.playerId,
+          bundleId: authData.bundleId,
+          platform: 'gamecenter'
+        };
+        fakeUsers[authData.playerId] = user;
+        return user;
+      }
+    }));
+
+    fakeUsers = {}; // reset fake users
+
+    return new Promise<void>((resolve) => {
+      server = app.listen(TEST_PORT, () => resolve());
+    });
+  });
+
+  afterEach(() => server.close());
+
+  describe("Game Center authentication", () => {
+    it("should reject invalid Game Center credentials", async () => {
+      assert.rejects(async () => {
+        await post("/auth/gamecenter", {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            playerId: "G:123456",
+            bundleId: "com.test.app",
+            timestamp: Date.now() / 1000,
+            salt: "invalidSalt",
+            signature: "invalidSignature",
+            publicKeyUrl: "https://static.gc.apple.com/public-key/gc-prod-4.cer"
+          }),
+        });
+      });
+    });
+
+    it("should require all Game Center fields", async () => {
+      assert.rejects(async () => {
+        await post("/auth/gamecenter", {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            playerId: "G:123456",
+            // missing required fields
+          }),
+        });
+      });
+    });
+  });
+
+  describe("caching test", () => {
+    it("should verify real token (first check)", async () => {
+      const result = await authenticateGameCenter(testToken);
+      assert.strictEqual(result.playerId, 'G:1965586982');
+      assert.strictEqual(result.bundleId, 'cloud.xtralife.gamecenterauth');
+    });
+
+    it("should take less time for cached checks", async () => {
+      const start = Date.now();
+      const result = await authenticateGameCenter(testToken);
+      const duration = Date.now() - start;
+      
+      assert.strictEqual(result.playerId, 'G:1965586982');
+      assert(duration < 10, 'Should be very fast due to caching');
+    });
+  });
+});


### PR DESCRIPTION
Added Apple Game Center authentication to the auth package.

Changes:
- New POST /auth/gamecenter endpoint for Game Center authentication
- GameCenter.ts module with Apple certificate validation and signature verification
- Certificate caching for performance
- Added test coverage for game center auth
- Fix for anonymous auth when request body is undefined

Resources:
- [GKLocalPlayer](https://developer.apple.com/documentation/gamekit/gklocalplayer)
- [Stackoverflow](https://stackoverflow.com/questions/15755489/setting-up-third-party-server-to-interact-with-game-center)