### PR TITLE
Fix ungraceful shutdown caused by input validation of  `onMessage`

### DIFF
--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -1113,12 +1113,20 @@ export abstract class Room<State extends object= any, Metadata= any, UserData = 
         : decode.number(buffer, it);
       const messageTypeHandler = this.onMessageHandlers[messageType];
 
-      let message = buffer.subarray(it.offset, buffer.byteLength);
-      debugMessage("received: '%s' -> %j (roomId: %s)", messageType, message, this.roomId);
+      let message
+      try {
+        message = buffer.subarray(it.offset, buffer.byteLength);
+        debugMessage("received: '%s' -> %j (roomId: %s)", messageType, message, this.roomId);
 
-      // custom message validation
-      if (messageTypeHandler?.validate !== undefined) {
-        message = messageTypeHandler.validate(message);
+        // custom message validation
+        if (messageTypeHandler?.validate !== undefined) {
+          message = messageTypeHandler.validate(message);
+        }
+
+      } catch (e) {
+        debugAndPrintError(e);
+        client.leave(Protocol.WS_CLOSE_WITH_ERROR);
+        return;
       }
 
       if (messageTypeHandler) {


### PR DESCRIPTION
The server would shut down ungracefully if validation of a `ROOM_DATA_BYTES` message failed. In contrast, validation failures for `ROOM_DATA` did not cause a crash, since that path already included proper error handling.

The `ROOM_DATA_BYTES` processing logic was missing a catch block, unlike the `ROOM_DATA` handler which safely guards against validation errors [here] (https://github.com/colyseus/colyseus/blob/1862e5daa08e1b8df04c327ce58083bb35eeb495/packages/core/src/Room.ts#L1079-L1101). 

This pull request adds improved error handling to the message processing logic in the `Room` class. Now, if an error occurs while handling an incoming message, the error is logged and the client is safely disconnected to prevent further issues.