### PR TITLE
Fixed email confirmation redirect loop in auth

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -283,6 +283,11 @@ Please give feedback and report any issues you may find at https://github.com/co
     });
 
     router.get("/confirm-email", async (req, res) => {
+      if (req.query.success || req.query.error) {
+        const html = await fs.readFile(path.join(htmlTemplatePath, "address-confirmation.html"), "utf-8");
+        return res.end(html);
+      }
+      
       // send "address confirmed" message
       if (typeof (auth.settings.onEmailConfirmed) !== "function") {
         return res.status(404).end('Not found.');


### PR DESCRIPTION
Previously the `/confirm-email` request was stuck in a loop and never displayed the intended web templates.
Now it checks for query params `success` and `error` to display the page and stop the loop.