### PR TITLE
@colyseus/core: removed unnecessary delete options.transport from server.ts

### DIFF
--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -132,7 +132,6 @@ export class Server {
     }
 
     const transport = options.transport || this.getDefaultTransport(options);
-    delete options.transport;
 
     this.transport = transport;
 


### PR DESCRIPTION
Fix: `transport` option becomes undefined after passing config to `Server`

This PR fixes an issue where the `transport` field inside the server configuration object becomes `undefined` after instantiating a new `Server(config)` instance.

Example:
```ts
const config = {
  gracefullyShutdown: true,
  transport: new uWebSocketsTransport({
    maxPayloadLength: 4096,
  }),
};

console.log('Transport', config.transport); // exists
const gameServer = new Server(config);
console.log('Transport', config.transport); // undefined
```

After calling `new Server(config)`, the `transport` property of the original config object is mutated and becomes `undefined`, which causes unexpected behavior when using `uWebSockets.js` and prevents proper integration with production server setups.

### **What This PR Does**
* Prevents mutation of the user-provided `config` object.
* Ensures `transport` remains intact after `new Server(config)` is called.
* Enables correct usage of `uWebSocketsTransport` as documented.
* Restores compatibility with setups involving Express or other HTTP frameworks alongside Colyseus.
