### PR TITLE
sdk: change type select text color from white to black for better visibility

### DIFF
--- a/packages/sdk/src/debug.ts
+++ b/packages/sdk/src/debug.ts
@@ -1048,7 +1048,7 @@ function openSendMessagesModal(uniquePanelId) {
     typeSelect.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
     typeSelect.style.border = '1px solid rgba(255, 255, 255, 0.2)';
     typeSelect.style.borderRadius = '4px';
-    typeSelect.style.color = '#fff';
+    typeSelect.style.color = '#000';
     typeSelect.style.fontSize = '12px';
     typeSelect.style.cursor = 'pointer';
     typeSelect.style.outline = 'none';


### PR DESCRIPTION
**Description:**
This PR addresses a visibility issue within the SDK by changing the text color of type select elements from white to black. This enhancement improves readability and user experience, especially on backgrounds where white text was previously hard to discern.

**Changes Made:**
- Modified the styling for type select elements within the SDK.
- Changed the text color property from white to black for improved contrast.

**Why these changes are needed:**
The previous white text color on certain backgrounds led to poor visibility, making it difficult for users to read and interact with the type selection. This change directly improves accessibility and usability.

**Screenshot:**
<img width="531" height="392" alt="sdk-bug" src="https://github.com/user-attachments/assets/2aa182a4-b6a4-48d8-858d-6082fdb7a0a3" />

