### PR TITLE
Add beforeUpgrade hook to uWebSocketsTransport for custom routing

### DIFF
--- a/packages/transport/uwebsockets-transport/src/uWebSocketsTransport.ts
+++ b/packages/transport/uwebsockets-transport/src/uWebSocketsTransport.ts
@@ -12,7 +12,17 @@ import('uwebsockets-express')
   .then((module) => uWebSocketsExpress.resolve(module))
   .catch((error) => uWebSocketsExpress.reject(error));
 
-export type TransportOptions = Omit<uWebSockets.WebSocketBehavior<any>, "upgrade" | "open" | "pong" | "close" | "message">;
+export type TransportOptions = Omit<uWebSockets.WebSocketBehavior<any>, "upgrade" | "open" | "pong" | "close" | "message"> & {
+  /**
+   * Called before WebSocket upgrade. Return false to prevent the upgrade.
+   * Useful for custom routing (e.g., Fly.io fly-replay header redirection).
+   */
+  beforeUpgrade?: (
+    res: uWebSockets.HttpResponse,
+    req: uWebSockets.HttpRequest,
+    context: uWebSockets.us_socket_context_t
+  ) => boolean | void | Promise<boolean | void>;
+};
 
 type RawWebSocketClient = uWebSockets.WebSocket<any> & {
   url: string,
@@ -56,7 +66,15 @@ export class uWebSocketsTransport extends Transport {
     this.app.ws('/*', {
       ...options,
 
-      upgrade: (res, req, context) => {
+      upgrade: async (res, req, context) => {
+        // Call beforeUpgrade hook if provided
+        if (options.beforeUpgrade) {
+          const result = await options.beforeUpgrade(res, req, context);
+          if (result === false) {
+            return;
+          }
+        }
+
         // get all headers
         const headers: { [id: string]: string } = {};
         req.forEach((key, value) => headers[key] = value);


### PR DESCRIPTION
Fixes #912

## Summary

Adds a `beforeUpgrade` hook to `uWebSocketsTransport` that allows intercepting WebSocket upgrade requests before the upgrade occurs. This enables custom routing logic for platforms without sticky WebSocket sessions.

## Changes

- Added `beforeUpgrade` option to `TransportOptions` type with signature matching the issue proposal
- Modified the `upgrade` handler to call `beforeUpgrade` before `res.upgrade()`
- If `beforeUpgrade` returns `false`, the upgrade is skipped, allowing the callback to handle the response

## Usage Example

```typescript
const flyMachineId = process.env.FLY_MACHINE_ID;

const transport = new uWebSocketsTransport({
  beforeUpgrade: async (res, req, context) => {
    if (!flyMachineId) return;

    const url = req.getUrl();
    const match = url.match(/\/([a-zA-Z0-9_\-]+)\/([a-zA-Z0-9_\-]+)$/);
    const targetProcessId = match?.[1];

    if (targetProcessId && targetProcessId !== matchMaker.processId) {
      const machineId = await matchMaker.presence.hget('process-to-machine', targetProcessId);
      if (machineId) {
        res.cork(() => {
          res.writeStatus('200 OK');
          res.writeHeader('fly-replay', `instance=${machineId}`);
          res.end();
        });
        return false;
      }
    }
  }
});
```

## Testing

The change follows the existing code patterns in the transport and maintains backward compatibility (the option is optional with no default behavior change).

```
 packages/transport/uwebsockets-transport/src/uWebSocketsTransport.ts | 20 ++++++++++++++++++--
 1 file changed, 18 insertions(+), 2 deletions(-)
```