### PR TITLE
fix auth FindUserByEmailCallback types

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -13,7 +13,7 @@ export type MayHaveUpgradeToken = { upgradingToken?: JwtPayload };
 
 export type RegisterWithEmailAndPasswordCallback<T = any> = (email: string, password: string, options: T & MayHaveUpgradeToken) => Promise<unknown>;
 export type RegisterAnonymouslyCallback<T = any> = (options: T) => Promise<unknown>;
-export type FindUserByEmailCallback = (email: string) => Promise<unknown & { password: string }>;
+export type FindUserByEmailCallback = (email: string) => Promise<(unknown & { password: string }) | null | undefined>;
 
 export type SendEmailConfirmationCallback = (email: string, html: string, confirmLink: string) => Promise<unknown>;
 export type EmailConfirmedCallback = (email: string) => Promise<unknown>;


### PR DESCRIPTION
## Fix: `FindUserByEmailCallback` missing `null | undefined` return types

### Problem
The `FindUserByEmailCallback` type did not account for cases where a user lookup returns no result. The return type was missing `null` and `undefined`, which are valid and expected outcomes when no user is found for the given email.

### Changes
- Updated `FindUserByEmailCallback` return type to include `null | undefined`

### Type of Change
- [x] Bug fix (incorrect type definition)