### PR TITLE
fix(uwebsockets-transport): catch closed socket error in error callback

### DIFF
--- a/packages/transport/uwebsockets-transport/src/uWebSocketClient.ts
+++ b/packages/transport/uwebsockets-transport/src/uWebSocketClient.ts
@@ -99,7 +99,9 @@ export class uWebSocketClient implements Client, ClientPrivate {
     if (cb) {
       // delay callback execution - uWS doesn't acknowledge when the message was sent
       // (same API as "ws" transport)
-      setTimeout(cb, 1);
+      setTimeout(() => {
+        try { cb(); } catch (_e) {}
+      }, 1);
     }
   }
 


### PR DESCRIPTION
By the time the setTimeout fires, the socket may already be closed, causing:
Error: Invalid access of closed uWS.WebSocket/SSLWebSocket
This wraps the callback in a try/catch to handle it gracefully

```
       Error: Invalid access of closed uWS.WebSocket/SSLWebSocket.
      at Timeout._onTimeout (/~/node_modules/@colyseus/uwebsockets-transport/build/uWebSocketsTransport.cjs:295:55)
      at listOnTimeout (node:internal/timers:585:17)
      at process.processTimers (node:internal/timers:521:7)```