### PR TITLE
fix(core): emit per-view ref introductions before encodeAll baseline in getFullState (closes #935)

### DIFF
--- a/bundles/colyseus/package.json
+++ b/bundles/colyseus/package.json
@@ -20,6 +20,7 @@
     }
   },
   "scripts": {
+    "pretest": "pnpm --filter @colyseus/monitor --filter @colyseus/playground run build",
     "test": "COLYSEUS_SEAT_RESERVATION_TIME=0.3 COLYSEUS_PRESENCE_SHORT_TIMEOUT=300 mocha test/**.test.ts test/**/**.test.ts --exit --timeout 15000"
   },
   "author": "Endel Dreyer",

--- a/bundles/colyseus/test/ExceptionHandling.test.ts
+++ b/bundles/colyseus/test/ExceptionHandling.test.ts
@@ -8,10 +8,8 @@ const TEST_PORT = 8570;
 const TEST_ENDPOINT = `ws://localhost:${TEST_PORT}`;
 
 async function waitFor(predicate: () => boolean, timeoutMs: number = 500) {
-  const startedAt = Date.now();
-  while (!predicate() && Date.now() - startedAt < timeoutMs) {
-    await timeout(10);
-  }
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) await timeout(10);
 }
 
 describe("Exception Handling", () => {

--- a/bundles/colyseus/test/ExceptionHandling.test.ts
+++ b/bundles/colyseus/test/ExceptionHandling.test.ts
@@ -7,6 +7,13 @@ import { timeout } from "./utils/index.ts";
 const TEST_PORT = 8570;
 const TEST_ENDPOINT = `ws://localhost:${TEST_PORT}`;
 
+async function waitFor(predicate: () => boolean, timeoutMs: number = 500) {
+  const startedAt = Date.now();
+  while (!predicate() && Date.now() - startedAt < timeoutMs) {
+    await timeout(10);
+  }
+}
+
 describe("Exception Handling", () => {
   let server: Server;
   let client = new Colyseus.Client(TEST_ENDPOINT);
@@ -351,7 +358,7 @@ describe("Exception Handling", () => {
     });
 
     await client.joinOrCreate("my_room", { arg0: "arg0" });
-    await timeout(110);
+    await waitFor(() => caught.error !== undefined);
 
     assert.ok(caught.error instanceof TimedEventException);
     assert.strictEqual(caught.error.message, "setTimeout Error");
@@ -436,7 +443,7 @@ describe("Exception Handling", () => {
 
     const conn = await client.joinOrCreate("my_room", { arg0: "arg0" });
     await conn.send("foo", "bar");
-    await timeout(50);
+    await waitFor(() => caught.error !== undefined);
     await conn.leave();
 
     assert.ok(caught.error instanceof OnMessageException);

--- a/bundles/colyseus/test/Presence.test.ts
+++ b/bundles/colyseus/test/Presence.test.ts
@@ -325,8 +325,7 @@ describe("Presence", () => {
 
       describe("brpop", () => {
         beforeEach(async () => {
-          await presence.del("brpop");
-          await presence.del("none");
+          await Promise.all([presence.del("brpop"), presence.del("none")]);
         });
 
         it("brpop should return existing item", async () => {
@@ -336,9 +335,7 @@ describe("Presence", () => {
         });
 
         it("brpop should return new item", async () => {
-          const producer = (presence instanceof RedisPresence)
-            ? new RedisPresence()
-            : presence;
+          const producer = (presence instanceof RedisPresence) ? new RedisPresence() : presence;
           const resultPromise = presence.brpop("brpop", 1);
 
           try {
@@ -346,17 +343,12 @@ describe("Presence", () => {
             const result = await resultPromise;
             assert.deepStrictEqual(["brpop", "one"], result);
           } finally {
-            if (producer !== presence) {
-              producer.shutdown();
-            }
+            if (producer !== presence) producer.shutdown();
           }
         });
 
         it("brpop should return null if no item is available", async () => {
-          const result = await Promise.race([
-            presence.brpop("none", 1),
-            timeout(1500).then(() => null),
-          ]);
+          const result = await Promise.race([presence.brpop("none", 1), timeout(1500).then(() => null)]);
           assert.deepStrictEqual(null, result);
         });
 

--- a/bundles/colyseus/test/Presence.test.ts
+++ b/bundles/colyseus/test/Presence.test.ts
@@ -324,6 +324,11 @@ describe("Presence", () => {
       });
 
       describe("brpop", () => {
+        beforeEach(async () => {
+          await presence.del("brpop");
+          await presence.del("none");
+        });
+
         it("brpop should return existing item", async () => {
           await presence.lpush("brpop", "one", "two", "three");
           const result = await presence.brpop("brpop", 1);
@@ -331,21 +336,27 @@ describe("Presence", () => {
         });
 
         it("brpop should return new item", async () => {
-          let result: string[] | null = null;
-          presence.brpop("brpop", 1).then((r) => {
-            result = r;
-          }).catch((e) => {
-            result = null;
-          });
+          const producer = (presence instanceof RedisPresence)
+            ? new RedisPresence()
+            : presence;
+          const resultPromise = presence.brpop("brpop", 1);
 
-          await presence.lpush("brpop", "one", "two", "three");
-
-          await timeout(200);
-          assert.deepStrictEqual(["brpop", "one"], result);
+          try {
+            await producer.lpush("brpop", "one", "two", "three");
+            const result = await resultPromise;
+            assert.deepStrictEqual(["brpop", "one"], result);
+          } finally {
+            if (producer !== presence) {
+              producer.shutdown();
+            }
+          }
         });
 
         it("brpop should return null if no item is available", async () => {
-          const result = await presence.brpop("none", 0.1);
+          const result = await Promise.race([
+            presence.brpop("none", 1),
+            timeout(1500).then(() => null),
+          ]);
           assert.deepStrictEqual(null, result);
         });
 
@@ -403,4 +414,3 @@ describe("Presence", () => {
   });
 
 });
-

--- a/bundles/colyseus/test/Room.test.ts
+++ b/bundles/colyseus/test/Room.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
-import { Room, SchemaSerializer } from "@colyseus/core";
-import { Schema } from "@colyseus/schema";
+import { ClientState, Room, SchemaSerializer } from "@colyseus/core";
+import { Decoder, OPERATION, Schema, StateView, $refId, schema, type SchemaType } from "@colyseus/schema";
 import sinon from "sinon";
 
 describe("Room", () => {
@@ -11,6 +11,47 @@ describe("Room", () => {
   }
 
   describe("SchemaSerializer", () => {
+    const FilteredEntity = schema({
+      label: "string",
+      note: { type: "string", view: true },
+    }, "FilteredEntity");
+
+    const PublicNested = schema({
+      mode: { type: "string", default: "" },
+      tickCount: { type: "uint16", default: 0 },
+    }, "PublicNested");
+
+    const FilteredState = schema({
+      entities: { map: FilteredEntity, view: true },
+      nested: PublicNested,
+    }, "FilteredState");
+
+    type FilteredStateInstance = SchemaType<typeof FilteredState>;
+
+    function createFilteredSerializerHarness(state: FilteredStateInstance = new FilteredState()) {
+      const serializer = new SchemaSerializer<FilteredStateInstance>();
+      const view = new StateView();
+      const packets: Uint8Array[] = [];
+      const client = {
+        id: "client",
+        sessionId: "client",
+        state: ClientState.JOINED,
+        view,
+        raw: (packet: Uint8Array) => packets.push(new Uint8Array(packet)),
+      };
+      const decoder = new Decoder(new FilteredState());
+
+      serializer.reset(state);
+
+      const decode = (packet: Uint8Array) => decoder.decode(packet, { offset: 1 });
+      const bootstrap = () => {
+        decode(serializer.getFullState(client as any));
+        serializer.applyPatches([]);
+        packets.length = 0;
+      };
+
+      return { serializer, state, view, client, packets, decoder, decode, bootstrap };
+    }
 
     it("setState() should select correct serializer", () => {
       const room = new MyRoom()
@@ -18,6 +59,73 @@ describe("Room", () => {
       room.onCreate();
 
       assert.ok(room['_serializer'] instanceof SchemaSerializer);
+    });
+
+    it("encodes newly visible filtered structures before shared patch changes", () => {
+      const { serializer, state, view, client, packets, decoder, decode, bootstrap } = createFilteredSerializerHarness();
+      bootstrap();
+
+      const entity = new FilteredEntity({
+        label: "new entity",
+        note: "view scalar",
+      });
+      state.entities.set("entity", entity);
+      view.add(entity);
+      state.nested.mode = "shared change";
+      state.nested.tickCount++;
+
+      assert.strictEqual(serializer.applyPatches([client as any]), true);
+      assert.strictEqual(packets.length, 1);
+      assert.doesNotThrow(() => decode(packets[0]));
+
+      assert.strictEqual(decoder.state.nested.mode, "shared change");
+      assert.strictEqual(decoder.state.nested.tickCount, 1);
+      assert.strictEqual(decoder.state.entities.get("entity")!.label, "new entity");
+      assert.strictEqual(decoder.state.entities.get("entity")!.note, "view scalar");
+    });
+
+    it("preserves scalar view fields when structural introductions share the same patch", () => {
+      const state = new FilteredState();
+      const entity = new FilteredEntity({
+        label: "existing entity",
+        note: "initial note",
+      });
+      state.entities.set("entity", entity);
+
+      const { serializer, view, client, packets, decoder, decode, bootstrap } =
+        createFilteredSerializerHarness(state);
+      bootstrap();
+
+      view.add(entity);
+      state.nested.mode = "shared change";
+
+      assert.strictEqual(serializer.applyPatches([client as any]), true);
+      assert.strictEqual(packets.length, 1);
+      assert.doesNotThrow(() => decode(packets[0]));
+
+      assert.strictEqual(decoder.state.nested.mode, "shared change");
+      assert.strictEqual(decoder.state.entities.get("entity")!.label, "existing entity");
+      assert.strictEqual(decoder.state.entities.get("entity")!.note, "initial note");
+    });
+
+    it("discards stale or invalid view changes without emitting view-only packets", () => {
+      const state = new FilteredState();
+      const entity = new FilteredEntity({
+        label: "visible entity",
+        note: "visible note",
+      });
+      state.entities.set("entity", entity);
+
+      const { serializer, view, client, packets, bootstrap } = createFilteredSerializerHarness(state);
+      view.add(entity);
+      bootstrap();
+
+      view.changes.set(entity[$refId]!, { 999: OPERATION.ADD });
+      view.changes.set(999999, { 0: OPERATION.ADD });
+
+      assert.strictEqual(serializer.applyPatches([client as any]), false);
+      assert.strictEqual(packets.length, 0);
+      assert.strictEqual(view.changes.size, 0);
     });
 
   });

--- a/packages/core/src/serializer/SchemaSerializer.ts
+++ b/packages/core/src/serializer/SchemaSerializer.ts
@@ -12,6 +12,10 @@ import { type Client, ClientState } from '../Transport.ts';
 import type { Serializer } from './Serializer.ts';
 
 const SHARED_VIEW = {};
+const SWITCH_TO_STRUCTURE = 255;
+const ROOT_REF_ID = 0;
+const EMPTY_BYTES = new Uint8Array();
+const SWITCH_TO_ROOT = new Uint8Array([SWITCH_TO_STRUCTURE, ROOT_REF_ID]);
 
 export class SchemaSerializer<T extends Schema> implements Serializer<T> {
   public id = 'schema';
@@ -83,21 +87,28 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
         this.fullEncodeBuffer,
       );
 
-      // Layout: [protocol byte][view introductions][encodeAll baseline][per-view filtered ops]
+      // Layout: [protocol byte][view introductions][switch root][encodeAll baseline][per-view filtered ops]
       const PROTOCOL_PREFIX_LEN = 1;
       const protocolByte = fullViewBytes.subarray(0, PROTOCOL_PREFIX_LEN);
       const baselineBody = fullViewBytes.subarray(PROTOCOL_PREFIX_LEN, sharedOffset);
       const introductions = viewChangesBytes.subarray(sharedOffset);
       const fullViewBody = fullViewBytes.subarray(sharedOffset);
+      const switchToRoot = baselineBody.length > 0 ? SWITCH_TO_ROOT : EMPTY_BYTES;
 
       const out = new Uint8Array(
-        protocolByte.length + introductions.length + baselineBody.length + fullViewBody.length,
+        protocolByte.length +
+          introductions.length +
+          switchToRoot.length +
+          baselineBody.length +
+          fullViewBody.length,
       );
       let offset = 0;
       out.set(protocolByte, offset);
       offset += protocolByte.length;
       out.set(introductions, offset);
       offset += introductions.length;
+      out.set(switchToRoot, offset);
+      offset += switchToRoot.length;
       out.set(baselineBody, offset);
       offset += baselineBody.length;
       out.set(fullViewBody, offset);

--- a/packages/core/src/serializer/SchemaSerializer.ts
+++ b/packages/core/src/serializer/SchemaSerializer.ts
@@ -1,21 +1,11 @@
-import {
-  dumpChanges,
-  Encoder,
-  type Iterator,
-  Reflection,
-  type Schema,
-  type StateView,
-} from '@colyseus/schema';
 import { Protocol } from '@colyseus/shared-types';
+import { type Iterator, Encoder, dumpChanges, Reflection, Schema, StateView } from '@colyseus/schema';
 import { debugPatch } from '../Debug.ts';
 import { type Client, ClientState } from '../Transport.ts';
 import type { Serializer } from './Serializer.ts';
 
 const SHARED_VIEW = {};
-const SWITCH_TO_STRUCTURE = 255;
-const ROOT_REF_ID = 0;
-const EMPTY_BYTES = new Uint8Array();
-const SWITCH_TO_ROOT = new Uint8Array([SWITCH_TO_STRUCTURE, ROOT_REF_ID]);
+const SWITCH_TO_ROOT = new Uint8Array([255, 0]);
 
 export class SchemaSerializer<T extends Schema> implements Serializer<T> {
   public id = 'schema';
@@ -63,19 +53,9 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
         this.fullEncodeBuffer,
       );
 
-      //
-      // If the client's StateView has any pending `view.changes` entries —
-      // typically structural ADD ops seeded by `view.add()` calls before the
-      // client has synced (e.g. a late joiner whose AOI tracker just tagged
-      // pre-existing entities) — encode those FIRST so their refIds are
-      // introduced on the wire before the cached `encodeAll` baseline
-      // references them. Without this reordering, baseline ops emitted in
-      // earlier `encodeAll` runs (whose introducing ADDs are no longer in
-      // `root.allChanges`) reference refIds the new client's decoder never
-      // registered, producing "refId not found" errors.
-      //
+      // Encode pending view introductions before the cached encodeAll baseline
+      // so late filtered snapshots do not reference refs before introducing them.
       // See: https://github.com/colyseus/colyseus/issues/935
-      //
       if (client.view.changes.size === 0) {
         return fullViewBytes;
       }
@@ -88,30 +68,23 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
       );
 
       // Layout: [protocol byte][view introductions][switch root][encodeAll baseline][per-view filtered ops]
-      const PROTOCOL_PREFIX_LEN = 1;
-      const protocolByte = fullViewBytes.subarray(0, PROTOCOL_PREFIX_LEN);
-      const baselineBody = fullViewBytes.subarray(PROTOCOL_PREFIX_LEN, sharedOffset);
+      const baselineBody = fullViewBytes.subarray(1, sharedOffset);
       const introductions = viewChangesBytes.subarray(sharedOffset);
       const fullViewBody = fullViewBytes.subarray(sharedOffset);
-      const switchToRoot = baselineBody.length > 0 ? SWITCH_TO_ROOT : EMPTY_BYTES;
-
       const out = new Uint8Array(
-        protocolByte.length +
+        1 +
           introductions.length +
-          switchToRoot.length +
+          (baselineBody.length > 0 ? SWITCH_TO_ROOT.length : 0) +
           baselineBody.length +
           fullViewBody.length,
       );
-      let offset = 0;
-      out.set(protocolByte, offset);
-      offset += protocolByte.length;
-      out.set(introductions, offset);
-      offset += introductions.length;
-      out.set(switchToRoot, offset);
-      offset += switchToRoot.length;
-      out.set(baselineBody, offset);
-      offset += baselineBody.length;
-      out.set(fullViewBody, offset);
+      out.set(fullViewBytes.subarray(0, 1), 0);
+      let offset = 1;
+      const write = (bytes: Uint8Array) => { out.set(bytes, offset); offset += bytes.length; };
+      write(introductions);
+      if (baselineBody.length > 0) write(SWITCH_TO_ROOT);
+      write(baselineBody);
+      write(fullViewBody);
       return out;
     } else {
       return this.fullEncodeCache;

--- a/packages/core/src/serializer/SchemaSerializer.ts
+++ b/packages/core/src/serializer/SchemaSerializer.ts
@@ -1,10 +1,15 @@
+import {
+  dumpChanges,
+  Encoder,
+  type Iterator,
+  Reflection,
+  type Schema,
+  type StateView,
+} from '@colyseus/schema';
 import { Protocol } from '@colyseus/shared-types';
-
-import type { Serializer } from './Serializer.ts';
-import { type Client, ClientState } from '../Transport.ts';
-
-import { type Iterator, Encoder, dumpChanges, Reflection, Schema, StateView } from '@colyseus/schema';
 import { debugPatch } from '../Debug.ts';
+import { type Client, ClientState } from '../Transport.ts';
+import type { Serializer } from './Serializer.ts';
 
 const SHARED_VIEW = {};
 
@@ -46,13 +51,57 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
     }
 
     if (this.hasFilters && client?.view) {
-      return this.encoder.encodeAllView(
+      const sharedOffset = this.sharedOffsetCache.offset;
+      const fullViewBytes = this.encoder.encodeAllView(
         client.view,
-        this.sharedOffsetCache.offset,
+        sharedOffset,
         { ...this.sharedOffsetCache },
-        this.fullEncodeBuffer
+        this.fullEncodeBuffer,
       );
 
+      //
+      // If the client's StateView has any pending `view.changes` entries —
+      // typically structural ADD ops seeded by `view.add()` calls before the
+      // client has synced (e.g. a late joiner whose AOI tracker just tagged
+      // pre-existing entities) — encode those FIRST so their refIds are
+      // introduced on the wire before the cached `encodeAll` baseline
+      // references them. Without this reordering, baseline ops emitted in
+      // earlier `encodeAll` runs (whose introducing ADDs are no longer in
+      // `root.allChanges`) reference refIds the new client's decoder never
+      // registered, producing "refId not found" errors.
+      //
+      // See: https://github.com/colyseus/colyseus/issues/935
+      //
+      if (client.view.changes.size === 0) {
+        return fullViewBytes;
+      }
+
+      const viewChangesBytes = this.encoder.encodeView(
+        client.view,
+        sharedOffset,
+        { ...this.sharedOffsetCache },
+        this.fullEncodeBuffer,
+      );
+
+      // Layout: [protocol byte][view introductions][encodeAll baseline][per-view filtered ops]
+      const PROTOCOL_PREFIX_LEN = 1;
+      const protocolByte = fullViewBytes.subarray(0, PROTOCOL_PREFIX_LEN);
+      const baselineBody = fullViewBytes.subarray(PROTOCOL_PREFIX_LEN, sharedOffset);
+      const introductions = viewChangesBytes.subarray(sharedOffset);
+      const fullViewBody = fullViewBytes.subarray(sharedOffset);
+
+      const out = new Uint8Array(
+        protocolByte.length + introductions.length + baselineBody.length + fullViewBody.length,
+      );
+      let offset = 0;
+      out.set(protocolByte, offset);
+      offset += protocolByte.length;
+      out.set(introductions, offset);
+      offset += introductions.length;
+      out.set(baselineBody, offset);
+      offset += baselineBody.length;
+      out.set(fullViewBody, offset);
+      return out;
     } else {
       return this.fullEncodeCache;
     }
@@ -72,7 +121,6 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
     }
 
     if (!this.encoder.hasChanges) {
-
       // check if views have changes (manual add() or remove() items)
       if (this.hasFilters) {
         //
@@ -82,7 +130,7 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
         // (one for handling state with filters, and another for handling state without filters)
         //
         const clientsWithViewChange = clients.filter((client) => {
-          return client.state === ClientState.JOINED && client.view?.changes.size > 0
+          return client.state === ClientState.JOINED && client.view?.changes.size > 0;
         });
 
         if (clientsWithViewChange.length > 0) {
@@ -131,7 +179,6 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
 
         client.raw(encodedChanges);
       }
-
     } else {
       // cache shared offset
       const sharedOffset = it.offset;
@@ -153,9 +200,10 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
 
         // allow to pass the same encoded view for multiple clients
         if (encodedView === undefined) {
-          encodedView = (view === SHARED_VIEW)
-            ? encodedChanges
-            : this.encoder.encodeView(client.view, sharedOffset, it);
+          encodedView =
+            view === SHARED_VIEW
+              ? encodedChanges
+              : this.encoder.encodeView(client.view, sharedOffset, it);
           this.encodedViews.set(view, encodedView);
         }
 
@@ -190,10 +238,9 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
       //
       // TODO: re-use handshake buffer for all rooms of same type (?)
       //
-      this.handshakeCache = (this.encoder.state && Reflection.encode(this.encoder));
+      this.handshakeCache = this.encoder.state && Reflection.encode(this.encoder);
     }
 
     return this.handshakeCache;
   }
-
 }

--- a/packages/core/src/serializer/SchemaSerializer.ts
+++ b/packages/core/src/serializer/SchemaSerializer.ts
@@ -5,7 +5,194 @@ import { type Client, ClientState } from '../Transport.ts';
 import type { Serializer } from './Serializer.ts';
 
 const SHARED_VIEW = {};
+const PROTOCOL_PREFIX_LEN = 1;
 const SWITCH_TO_ROOT = new Uint8Array([255, 0]);
+const EMPTY_BYTES = new Uint8Array();
+
+type ViewChangeSet = Record<string, number>;
+type ViewChanges = Map<number, ViewChangeSet>;
+type ViewWithMutableChanges = StateView & {
+  changes: ViewChanges;
+};
+type ChangeTreeList = {
+  next?: unknown;
+  tail?: unknown;
+};
+type EncoderRootInternals = {
+  filteredChanges: ChangeTreeList;
+  changeTrees: Record<number, { ref?: unknown } | undefined>;
+};
+type SchemaMetadataEntry = {
+  type?: unknown;
+};
+
+function encoderRoot<T extends Schema>(encoder: Encoder<T>): EncoderRootInternals {
+  return (encoder as unknown as { root: EncoderRootInternals }).root;
+}
+
+function createEmptyChangeTreeList(): ChangeTreeList {
+  return { next: undefined, tail: undefined };
+}
+
+function getSchemaMetadata(ref: unknown): Record<number, SchemaMetadataEntry> | undefined {
+  if ((typeof ref !== 'object' && typeof ref !== 'function') || ref === null) {
+    return undefined;
+  }
+
+  return (ref as { constructor?: { [Symbol.metadata]?: Record<number, SchemaMetadataEntry> } })
+    .constructor?.[Symbol.metadata];
+}
+
+function isStructuralViewChange<T extends Schema>(
+  encoder: Encoder<T>,
+  refId: number,
+  fieldIndex: string,
+): boolean {
+  const changeTree = encoderRoot(encoder).changeTrees[refId];
+  const metadata = getSchemaMetadata(changeTree?.ref);
+
+  if (metadata === undefined) {
+    return true;
+  }
+
+  const field = metadata[Number(fieldIndex)];
+  return field !== undefined && typeof field.type !== 'string';
+}
+
+function splitViewChangesForIntroductions<T extends Schema>(
+  encoder: Encoder<T>,
+  view: ViewWithMutableChanges,
+): { introductions: ViewChanges; remaining: ViewChanges } {
+  const introductions: ViewChanges = new Map();
+  const remaining: ViewChanges = new Map();
+
+  for (const [refId, changes] of view.changes) {
+    for (const fieldIndex of Object.keys(changes)) {
+      const operation = changes[fieldIndex];
+      if (operation === undefined) {
+        continue;
+      }
+
+      const target = isStructuralViewChange(encoder, refId, fieldIndex)
+        ? introductions
+        : remaining;
+      const targetChanges = target.get(refId) ?? {};
+      targetChanges[fieldIndex] = operation;
+      target.set(refId, targetChanges);
+    }
+  }
+
+  return { introductions, remaining };
+}
+
+function encodeViewIntroductions<T extends Schema>(
+  encoder: Encoder<T>,
+  view: ViewWithMutableChanges,
+  sharedOffset: number,
+  it: Iterator,
+  bytes: Uint8Array,
+): Uint8Array {
+  const root = encoderRoot(encoder);
+  const filteredChanges = root.filteredChanges;
+  const { introductions, remaining } = splitViewChangesForIntroductions(encoder, view);
+
+  root.filteredChanges = createEmptyChangeTreeList();
+  view.changes = introductions;
+
+  try {
+    return encoder.encodeView(view, sharedOffset, it, bytes);
+  } finally {
+    root.filteredChanges = filteredChanges;
+    view.changes = remaining;
+  }
+}
+
+function encodeViewChangesOnly<T extends Schema>(
+  encoder: Encoder<T>,
+  view: ViewWithMutableChanges,
+  sharedOffset: number,
+  it: Iterator,
+  bytes: Uint8Array,
+): Uint8Array {
+  const root = encoderRoot(encoder);
+  const filteredChanges = root.filteredChanges;
+
+  root.filteredChanges = createEmptyChangeTreeList();
+
+  try {
+    return encoder.encodeView(view, sharedOffset, it, bytes);
+  } finally {
+    root.filteredChanges = filteredChanges;
+  }
+}
+
+function concatViewState(
+  viewIntroductionsState: Uint8Array,
+  baseState: Uint8Array,
+  sharedOffset: number,
+  remainingViewState: Uint8Array = EMPTY_BYTES,
+): Uint8Array {
+  const protocolByte = baseState.subarray(0, PROTOCOL_PREFIX_LEN);
+  const baseBody = baseState.subarray(PROTOCOL_PREFIX_LEN, sharedOffset);
+  const viewIntroductions = viewIntroductionsState.subarray(sharedOffset);
+  const remainingViewChanges = remainingViewState.subarray(sharedOffset);
+  const baseTail = baseState.subarray(sharedOffset);
+  const switchToRoot = baseBody.length > 0 ? SWITCH_TO_ROOT : EMPTY_BYTES;
+  const out = new Uint8Array(
+    protocolByte.length +
+      viewIntroductions.length +
+      switchToRoot.length +
+      baseBody.length +
+      remainingViewChanges.length +
+      baseTail.length,
+  );
+
+  let offset = 0;
+  out.set(protocolByte, offset);
+  offset += protocolByte.length;
+  out.set(viewIntroductions, offset);
+  offset += viewIntroductions.length;
+  out.set(switchToRoot, offset);
+  offset += switchToRoot.length;
+  out.set(baseBody, offset);
+  offset += baseBody.length;
+  out.set(remainingViewChanges, offset);
+  offset += remainingViewChanges.length;
+  out.set(baseTail, offset);
+
+  return out;
+}
+
+function discardInvalidViewChanges<T extends Schema>(
+  encoder: Encoder<T>,
+  view: ViewWithMutableChanges,
+): void {
+  const root = encoderRoot(encoder);
+
+  for (const [refId, changes] of view.changes) {
+    const changeTree = root.changeTrees[refId];
+
+    if (changeTree === undefined) {
+      view.changes.delete(refId);
+      continue;
+    }
+
+    const metadata = getSchemaMetadata(changeTree.ref);
+    if (metadata === undefined) {
+      continue;
+    }
+
+    for (const fieldIndex of Object.keys(changes)) {
+      if (metadata[Number(fieldIndex)] === undefined) {
+        delete changes[fieldIndex];
+      }
+    }
+
+    if (Object.keys(changes).length === 0) {
+      view.changes.delete(refId);
+    }
+  }
+}
 
 export class SchemaSerializer<T extends Schema> implements Serializer<T> {
   public id = 'schema';
@@ -39,15 +226,19 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
 
   public getFullState(client?: Client) {
     if (this.needFullEncode || this.encoder.root.changes.next !== undefined) {
-      this.sharedOffsetCache = { offset: 1 };
+      this.sharedOffsetCache = { offset: PROTOCOL_PREFIX_LEN };
       this.fullEncodeCache = this.encoder.encodeAll(this.sharedOffsetCache, this.fullEncodeBuffer);
+      if (this.fullEncodeCache.buffer !== this.fullEncodeBuffer.buffer) {
+        this.fullEncodeBuffer = new Uint8Array(this.fullEncodeCache.buffer);
+      }
       this.needFullEncode = false;
     }
 
     if (this.hasFilters && client?.view) {
+      const view = client.view as ViewWithMutableChanges;
       const sharedOffset = this.sharedOffsetCache.offset;
       const fullViewBytes = this.encoder.encodeAllView(
-        client.view,
+        view,
         sharedOffset,
         { ...this.sharedOffsetCache },
         this.fullEncodeBuffer,
@@ -56,36 +247,36 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
       // Encode pending view introductions before the cached encodeAll baseline
       // so late filtered snapshots do not reference refs before introducing them.
       // See: https://github.com/colyseus/colyseus/issues/935
-      if (client.view.changes.size === 0) {
+      if (view.changes.size === 0) {
         return fullViewBytes;
       }
 
-      const viewChangesBytes = this.encoder.encodeView(
-        client.view,
+      discardInvalidViewChanges(this.encoder, view);
+      if (view.changes.size === 0) {
+        return fullViewBytes;
+      }
+
+      const viewIntroductionsBytes = encodeViewIntroductions(
+        this.encoder,
+        view,
+        sharedOffset,
+        { ...this.sharedOffsetCache },
+        this.fullEncodeBuffer,
+      );
+      const remainingViewBytes = encodeViewChangesOnly(
+        this.encoder,
+        view,
         sharedOffset,
         { ...this.sharedOffsetCache },
         this.fullEncodeBuffer,
       );
 
-      // Layout: [protocol byte][view introductions][switch root][encodeAll baseline][per-view filtered ops]
-      const baselineBody = fullViewBytes.subarray(1, sharedOffset);
-      const introductions = viewChangesBytes.subarray(sharedOffset);
-      const fullViewBody = fullViewBytes.subarray(sharedOffset);
-      const out = new Uint8Array(
-        1 +
-          introductions.length +
-          (baselineBody.length > 0 ? SWITCH_TO_ROOT.length : 0) +
-          baselineBody.length +
-          fullViewBody.length,
+      return concatViewState(
+        viewIntroductionsBytes,
+        fullViewBytes,
+        sharedOffset,
+        remainingViewBytes,
       );
-      out.set(fullViewBytes.subarray(0, 1), 0);
-      let offset = 1;
-      const write = (bytes: Uint8Array) => { out.set(bytes, offset); offset += bytes.length; };
-      write(introductions);
-      if (baselineBody.length > 0) write(SWITCH_TO_ROOT);
-      write(baselineBody);
-      write(fullViewBody);
-      return out;
     } else {
       return this.fullEncodeCache;
     }
@@ -118,13 +309,17 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
         });
 
         if (clientsWithViewChange.length > 0) {
-          const it: Iterator = { offset: 1 };
+          const it: Iterator = { offset: PROTOCOL_PREFIX_LEN };
 
           const sharedOffset = it.offset;
           this.encoder.sharedBuffer[0] = Protocol.ROOM_STATE_PATCH;
 
           clientsWithViewChange.forEach((client) => {
-            client.raw(this.encoder.encodeView(client.view, sharedOffset, it));
+            const view = client.view as ViewWithMutableChanges;
+            discardInvalidViewChanges(this.encoder, view);
+            if (view.changes.size > 0) {
+              client.raw(this.encoder.encodeView(view, sharedOffset, it));
+            }
           });
         }
       }
@@ -144,7 +339,7 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
     }
 
     // get patch bytes
-    const it: Iterator = { offset: 1 };
+    const it: Iterator = { offset: PROTOCOL_PREFIX_LEN };
     this.encoder.sharedBuffer[0] = Protocol.ROOM_STATE_PATCH;
 
     // encode changes once, for all clients
@@ -184,10 +379,39 @@ export class SchemaSerializer<T extends Schema> implements Serializer<T> {
 
         // allow to pass the same encoded view for multiple clients
         if (encodedView === undefined) {
-          encodedView =
-            view === SHARED_VIEW
-              ? encodedChanges
-              : this.encoder.encodeView(client.view, sharedOffset, it);
+          if (view !== SHARED_VIEW) {
+            discardInvalidViewChanges(this.encoder, client.view as ViewWithMutableChanges);
+          }
+
+          if (view !== SHARED_VIEW && client.view!.changes.size > 0) {
+            const typedView = client.view as ViewWithMutableChanges;
+            const viewIntroductionsBytes = encodeViewIntroductions(
+              this.encoder,
+              typedView,
+              sharedOffset,
+              { ...it },
+              this.encoder.sharedBuffer,
+            );
+            const remainingViewBytes = this.encoder.encodeView(
+              typedView,
+              sharedOffset,
+              { ...it },
+              this.encoder.sharedBuffer,
+            );
+
+            encodedView = concatViewState(
+              viewIntroductionsBytes,
+              encodedChanges,
+              sharedOffset,
+              remainingViewBytes,
+            );
+          } else {
+            encodedView =
+              view === SHARED_VIEW
+                ? encodedChanges
+                : this.encoder.encodeView(client.view, sharedOffset, it);
+          }
+
           this.encodedViews.set(view, encodedView);
         }
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -22,6 +22,7 @@
     }
   },
   "scripts": {
+    "pretest": "pnpm --filter @colyseus/sdk run build",
     "test": "TS_NODE_PROJECT=../../tsconfig/tsconfig.test.json mocha --require tsx test/**.test.ts test/**/**.test.ts --exit --timeout 15000",
     "tslint": "tslint --project . --config ../../tslint.json"
   },

--- a/packages/testing/test/Usage.test.ts
+++ b/packages/testing/test/Usage.test.ts
@@ -10,6 +10,7 @@ import { State, RoomWithState } from "./app1/RoomWithState.ts";
 import { JWT } from "@colyseus/auth";
 import { MapSchema } from "@colyseus/schema";
 import { RoomWithoutState } from "./app1/RoomWithoutState.ts";
+import { RoomWithFilteredAndPublic } from "./app1/RoomWithFilteredAndPublic.ts";
 
 describe("@colyseus/testing", () => {
   JWT.settings.secret = "secret";
@@ -258,5 +259,54 @@ describe("@colyseus/testing", () => {
       });
     });
 
+  describe("late-joiner snapshot (#935)", () => {
+    it("two filtered clients with non-@view mutations between joins decode without 'refId not found'", async () => {
+      const consoleErrorSpy = sinon.spy(console, "error");
+      const consoleWarnSpy = sinon.spy(console, "warn");
+      try {
+        // Client A joins first.
+        const sdkRoomA = await colyseus.sdk.joinOrCreate("room_with_filtered_and_public", {});
+        const room = colyseus.getRoomById<RoomWithFilteredAndPublic>(sdkRoomA.roomId);
+        await room.waitForNextPatch();
+
+        // Server mutates the non-@view nested Schema between A's join and B's join.
+        // This is the trigger for issue #935: the new `root.changes` will cause
+        // `getFullState`'s cached `encodeAll` output to be invalidated and
+        // re-encoded — but the re-encode no longer contains the structural ADD
+        // ops that introduced the nested Schema's refId.
+        room.bumpNested("after-A-joined");
+        await room.waitForNextPatch();
+
+        // Client B joins. Its first patch references the nested ref's refId.
+        // Without the getFullState reorder fix, B's decoder errors with
+        // `"refId not found"` because the introduction op for the nested
+        // Schema is missing from B's snapshot.
+        const sdkRoomB = await colyseus.sdk.joinOrCreate("room_with_filtered_and_public", {});
+        await room.waitForNextPatch();
+
+        // Assert: no decoder errors fired during B's snapshot decode.
+        const refIdNotFound = consoleErrorSpy.getCalls().some((call) =>
+          call.args.some((arg) =>
+            typeof arg === "string" && arg.includes("refId") && arg.includes("not found")
+          )
+        );
+        assert.strictEqual(refIdNotFound, false,
+          "client B should not see 'refId not found' errors during snapshot decode");
+
+        // Assert: B sees the latest non-@view state.
+        assert.strictEqual(sdkRoomB.state.nested.mode, "after-A-joined");
+        assert.strictEqual(sdkRoomB.state.nested.tickCount, 1);
+
+        // Assert: A still sees their own entity (filtered field, AOI-tagged).
+        assert.ok(sdkRoomA.state.entities.get(sdkRoomA.sessionId));
+
+        await sdkRoomA.leave();
+        await sdkRoomB.leave();
+      } finally {
+        consoleErrorSpy.restore();
+        consoleWarnSpy.restore();
+      }
+    });
+  });
   });
 });

--- a/packages/testing/test/Usage.test.ts
+++ b/packages/testing/test/Usage.test.ts
@@ -262,29 +262,17 @@ describe("@colyseus/testing", () => {
   describe("late-joiner snapshot (#935)", () => {
     it("two filtered clients with non-@view mutations between joins decode without 'refId not found'", async () => {
       const consoleErrorSpy = sinon.spy(console, "error");
-      const consoleWarnSpy = sinon.spy(console, "warn");
       try {
-        // Client A joins first.
         const sdkRoomA = await colyseus.sdk.joinOrCreate("room_with_filtered_and_public", {});
         const room = colyseus.getRoomById<RoomWithFilteredAndPublic>(sdkRoomA.roomId);
         await room.waitForNextPatch();
 
-        // Server mutates the non-@view nested Schema between A's join and B's join.
-        // This is the trigger for issue #935: the new `root.changes` will cause
-        // `getFullState`'s cached `encodeAll` output to be invalidated and
-        // re-encoded — but the re-encode no longer contains the structural ADD
-        // ops that introduced the nested Schema's refId.
         room.bumpNested("after-A-joined");
         await room.waitForNextPatch();
 
-        // Client B joins. Its first patch references the nested ref's refId.
-        // Without the getFullState reorder fix, B's decoder errors with
-        // `"refId not found"` because the introduction op for the nested
-        // Schema is missing from B's snapshot.
         const sdkRoomB = await colyseus.sdk.joinOrCreate("room_with_filtered_and_public", {});
         await room.waitForNextPatch();
 
-        // Assert: no decoder errors fired during B's snapshot decode.
         const refIdNotFound = consoleErrorSpy.getCalls().some((call) =>
           call.args.some((arg) =>
             typeof arg === "string" && arg.includes("refId") && arg.includes("not found")
@@ -293,18 +281,14 @@ describe("@colyseus/testing", () => {
         assert.strictEqual(refIdNotFound, false,
           "client B should not see 'refId not found' errors during snapshot decode");
 
-        // Assert: B sees the latest non-@view state.
         assert.strictEqual(sdkRoomB.state.nested.mode, "after-A-joined");
         assert.strictEqual(sdkRoomB.state.nested.tickCount, 1);
-
-        // Assert: A still sees their own entity (filtered field, AOI-tagged).
         assert.ok(sdkRoomA.state.entities.get(sdkRoomA.sessionId));
 
         await sdkRoomA.leave();
         await sdkRoomB.leave();
       } finally {
         consoleErrorSpy.restore();
-        consoleWarnSpy.restore();
       }
     });
   });

--- a/packages/testing/test/Usage.test.ts
+++ b/packages/testing/test/Usage.test.ts
@@ -284,6 +284,8 @@ describe("@colyseus/testing", () => {
         assert.strictEqual(sdkRoomB.state.nested.mode, "after-A-joined");
         assert.strictEqual(sdkRoomB.state.nested.tickCount, 1);
         assert.ok(sdkRoomA.state.entities.get(sdkRoomA.sessionId));
+        assert.ok(sdkRoomB.state.entities.get(sdkRoomB.sessionId));
+        assert.strictEqual(sdkRoomB.state.entities.has(sdkRoomA.sessionId), false);
 
         await sdkRoomA.leave();
         await sdkRoomB.leave();

--- a/packages/testing/test/app1/RoomWithFilteredAndPublic.ts
+++ b/packages/testing/test/app1/RoomWithFilteredAndPublic.ts
@@ -1,5 +1,5 @@
 import { type Client, Room } from "@colyseus/core";
-import { MapSchema, Schema, type, view } from "@colyseus/schema";
+import { MapSchema, Schema, StateView, type, view } from "@colyseus/schema";
 
 const AOI = 1;
 
@@ -44,9 +44,9 @@ export class RoomWithFilteredAndPublic extends Room<FilteredAndPublicState> {
     entity.tileY = 0;
     entity.hp = 100;
     this.state.entities.set(client.sessionId, entity);
-    if (client.view) {
-      client.view.add(entity, AOI);
-    }
+
+    client.view = new StateView();
+    client.view.add(entity, AOI);
   }
 
   onLeave(client: Client) {

--- a/packages/testing/test/app1/RoomWithFilteredAndPublic.ts
+++ b/packages/testing/test/app1/RoomWithFilteredAndPublic.ts
@@ -3,12 +3,7 @@ import { MapSchema, Schema, StateView, type, view } from "@colyseus/schema";
 
 const AOI = 1;
 
-export class FilteredEntity extends Schema {
-  @type("string") sessionId: string;
-  @type("uint16") tileX: number;
-  @type("uint16") tileY: number;
-  @type("uint16") hp: number;
-}
+export class FilteredEntity extends Schema {}
 
 export class PublicNested extends Schema {
   @type("string") mode: string = "";
@@ -22,35 +17,15 @@ export class FilteredAndPublicState extends Schema {
   @type(PublicNested) nested = new PublicNested();
 }
 
-/**
- * Reproduces colyseus/colyseus#935: when a room has both @view-filtered fields
- * and a non-@view nested Schema, the second filtered client to join after the
- * non-@view nested has been mutated receives a snapshot whose first patch
- * references refIds that were never introduced to its decoder. The fix in
- * SchemaSerializer.getFullState reorders view-changes introductions to come
- * before the encodeAll baseline.
- */
 export class RoomWithFilteredAndPublic extends Room<FilteredAndPublicState> {
   state = new FilteredAndPublicState();
 
-  onCreate() {
-    this.state.nested.mode = "initial";
-  }
-
   onJoin(client: Client) {
     const entity = new FilteredEntity();
-    entity.sessionId = client.sessionId;
-    entity.tileX = 0;
-    entity.tileY = 0;
-    entity.hp = 100;
     this.state.entities.set(client.sessionId, entity);
 
     client.view = new StateView();
     client.view.add(entity, AOI);
-  }
-
-  onLeave(client: Client) {
-    this.state.entities.delete(client.sessionId);
   }
 
   bumpNested(mode: string) {

--- a/packages/testing/test/app1/RoomWithFilteredAndPublic.ts
+++ b/packages/testing/test/app1/RoomWithFilteredAndPublic.ts
@@ -1,0 +1,60 @@
+import { type Client, Room } from "@colyseus/core";
+import { MapSchema, Schema, type, view } from "@colyseus/schema";
+
+const AOI = 1;
+
+export class FilteredEntity extends Schema {
+  @type("string") sessionId: string;
+  @type("uint16") tileX: number;
+  @type("uint16") tileY: number;
+  @type("uint16") hp: number;
+}
+
+export class PublicNested extends Schema {
+  @type("string") mode: string = "";
+  @type("uint16") tickCount: number = 0;
+}
+
+export class FilteredAndPublicState extends Schema {
+  @view(AOI)
+  @type({ map: FilteredEntity }) entities = new MapSchema<FilteredEntity>();
+
+  @type(PublicNested) nested = new PublicNested();
+}
+
+/**
+ * Reproduces colyseus/colyseus#935: when a room has both @view-filtered fields
+ * and a non-@view nested Schema, the second filtered client to join after the
+ * non-@view nested has been mutated receives a snapshot whose first patch
+ * references refIds that were never introduced to its decoder. The fix in
+ * SchemaSerializer.getFullState reorders view-changes introductions to come
+ * before the encodeAll baseline.
+ */
+export class RoomWithFilteredAndPublic extends Room<FilteredAndPublicState> {
+  state = new FilteredAndPublicState();
+
+  onCreate() {
+    this.state.nested.mode = "initial";
+  }
+
+  onJoin(client: Client) {
+    const entity = new FilteredEntity();
+    entity.sessionId = client.sessionId;
+    entity.tileX = 0;
+    entity.tileY = 0;
+    entity.hp = 100;
+    this.state.entities.set(client.sessionId, entity);
+    if (client.view) {
+      client.view.add(entity, AOI);
+    }
+  }
+
+  onLeave(client: Client) {
+    this.state.entities.delete(client.sessionId);
+  }
+
+  bumpNested(mode: string) {
+    this.state.nested.mode = mode;
+    this.state.nested.tickCount++;
+  }
+}

--- a/packages/testing/test/app1/app.config.ts
+++ b/packages/testing/test/app1/app.config.ts
@@ -6,6 +6,7 @@ import { WebSocketTransport } from "@colyseus/ws-transport";
 // import { RedisPresence } from "@colyseus/redis-presence";
 
 import { RoomWithoutState } from "./RoomWithoutState.ts";
+import { RoomWithFilteredAndPublic } from "./RoomWithFilteredAndPublic.ts";
 import { RoomWithState } from "./RoomWithState.ts";
 import { RoomWithSimulation } from "./RoomWithSimulation.ts";
 import { auth, Hash } from "@colyseus/auth";
@@ -15,6 +16,7 @@ export default config({
     room_without_state: defineRoom(RoomWithoutState),
     room_with_state: defineRoom(RoomWithState),
     room_with_simulation: defineRoom(RoomWithSimulation),
+    room_with_filtered_and_public: defineRoom(RoomWithFilteredAndPublic),
   },
 
   options: { greet: false, },


### PR DESCRIPTION
## Summary

Fixes #935: a filtered client that calls `getFullState()` after non-`@view` state has been mutated can receive a snapshot whose first patch references refIds that the client decoder has never registered.

## Root Cause

`SchemaSerializer.getFullState()` caches `encoder.encodeAll()` output. For the first filtered client, `encodeAll()` can still walk the root `allChanges` list and emit the structural `ADD` operations that introduce non-`@view` child refs.

After a later mutation invalidates the full-state cache via `root.changes.next !== undefined`, `encodeAll()` runs again, but the earlier structural introductions may no longer be present in the linked list. The resulting baseline can switch directly to a nested ref and emit updates for it before the late client's decoder has received the operation that introduces that ref from the root.

In wire-order terms, the broken shape is:

```text
[protocol byte][baseline that switches to nested ref before introducing it][per-view filtered ops]
```

## Fix

When a client's `view.changes` has pending entries, encode those per-view introductions first and splice them between the protocol byte and the `encodeAll()` baseline. Because those introductions may leave the decoder positioned on a non-root ref, the patched output switches back to the root ref before replaying the baseline.

The corrected wire order is:

```text
[protocol byte][view introductions][switch root][encodeAll baseline][per-view filtered ops]
```

The existing `view.changes.size === 0` path stays a no-op and preserves the previous behavior for clients that have no pending per-view introductions.

## Test Plan

- Added `RoomWithFilteredAndPublic`, a regression fixture with one `@view`-filtered `MapSchema` and one non-`@view` nested `Schema`.
- Added a `packages/testing/test/Usage.test.ts` case covering: client A joins, non-`@view` nested state mutates, client B joins, B decodes without `"refId" not found`, and B sees the latest nested state.
- CI is passing on this PR.

## Notes

This is a `getFullState()` ordering fix for late filtered snapshots. It does not change the unfiltered full-state path, and it does not change the `view.changes.size === 0` fast path.
