### PR TITLE
fix(core): support strict TypeScript declaration consumers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,9 @@
   "version": "0.17.44",
   "description": "Multiplayer Framework for Node.js.",
   "type": "module",
+  "scripts": {
+    "test": "tsc --noEmit --strict --skipLibCheck false --module NodeNext --moduleResolution NodeNext --target ES2022 --typeRoots ../../node_modules/@types --types node test/strict-declarations.ts && node --input-type=module -e \"import assert from 'node:assert/strict'; import fs from 'node:fs'; assert.match(fs.readFileSync('build/presence/LocalPresence.d.ts', 'utf8'), /subscriptions: EventEmitter;/);\""
+  },
   "input": "./src/index.ts",
   "main": "./build/index.cjs",
   "module": "./src/index.ts",

--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -1885,7 +1885,7 @@ type DefineRoomOptions<T extends RoomOptions = RoomOptions> =
   ThisType<Room<T>>
 ;
 
-export function room<T>(options: DefineRoomOptions<T>) {
+export function room<T extends RoomOptions>(options: DefineRoomOptions<T>) {
   class _ extends Room<T> {
     messages = options.messages;
 

--- a/packages/core/src/errors/RoomExceptions.ts
+++ b/packages/core/src/errors/RoomExceptions.ts
@@ -26,11 +26,11 @@ export type RoomException<R extends Room = Room> =
   TimedEventException;
 
 export class OnCreateException<R extends Room = Room> extends Error {
-  options: Parameters<R['onCreate']>[0];
+  options: Parameters<NonNullable<R['onCreate']>>[0];
   constructor(
     cause: Error,
     message: string,
-    options:  Parameters<R['onCreate']>[0],
+    options:  Parameters<NonNullable<R['onCreate']>>[0],
   ) {
     super(message, { cause });
     this.name = 'OnCreateException';
@@ -55,15 +55,15 @@ export class OnAuthException<R extends Room = Room> extends Error {
 }
 
 export class OnJoinException<R extends Room = Room> extends Error {
-  client: Parameters<R['onJoin']>[0];
-  options: Parameters<R['onJoin']>[1];
-  auth: Parameters<R['onJoin']>[2];
+  client: Parameters<NonNullable<R['onJoin']>>[0];
+  options: Parameters<NonNullable<R['onJoin']>>[1];
+  auth: Parameters<NonNullable<R['onJoin']>>[2];
   constructor(
     cause: Error,
     message: string,
-    client: Parameters<R['onJoin']>[0],
-    options: Parameters<R['onJoin']>[1],
-    auth: Parameters<R['onJoin']>[2],
+    client: Parameters<NonNullable<R['onJoin']>>[0],
+    options: Parameters<NonNullable<R['onJoin']>>[1],
+    auth: Parameters<NonNullable<R['onJoin']>>[2],
   ) {
     super(message, { cause });
     this.name = 'OnJoinException';
@@ -74,13 +74,13 @@ export class OnJoinException<R extends Room = Room> extends Error {
 }
 
 export class OnLeaveException<R extends Room = Room> extends Error {
-  client: Parameters<R['onLeave']>[0];
-  consented: Parameters<R['onLeave']>[1];
+  client: Parameters<NonNullable<R['onLeave']>>[0];
+  consented: Parameters<NonNullable<R['onLeave']>>[1];
   constructor(
     cause: Error,
     message: string,
-    client: Parameters<R['onLeave']>[0],
-    consented: Parameters<R['onLeave']>[1],
+    client: Parameters<NonNullable<R['onLeave']>>[0],
+    consented: Parameters<NonNullable<R['onLeave']>>[1],
   ) {
     super(message, { cause });
     this.name = 'OnLeaveException';
@@ -90,13 +90,13 @@ export class OnLeaveException<R extends Room = Room> extends Error {
 }
 
 export class OnDropException<R extends Room = Room> extends Error {
-  client: Parameters<R['onDrop']>[0];
-  code: Parameters<R['onDrop']>[1];
+  client: Parameters<NonNullable<R['onDrop']>>[0];
+  code: Parameters<NonNullable<R['onDrop']>>[1];
   constructor(
     cause: Error,
     message: string,
-    client: Parameters<R['onDrop']>[0],
-    code: Parameters<R['onDrop']>[1],
+    client: Parameters<NonNullable<R['onDrop']>>[0],
+    code: Parameters<NonNullable<R['onDrop']>>[1],
   ) {
     super(message, { cause });
     this.name = 'OnDropException';
@@ -106,11 +106,11 @@ export class OnDropException<R extends Room = Room> extends Error {
 }
 
 export class OnReconnectException<R extends Room = Room> extends Error {
-  client: Parameters<R['onReconnect']>[0];
+  client: Parameters<NonNullable<R['onReconnect']>>[0];
   constructor(
     cause: Error,
     message: string,
-    client: Parameters<R['onReconnect']>[0],
+    client: Parameters<NonNullable<R['onReconnect']>>[0],
   ) {
     super(message, { cause });
     this.name = 'OnReconnectException';

--- a/packages/core/src/presence/LocalPresence.ts
+++ b/packages/core/src/presence/LocalPresence.ts
@@ -8,7 +8,7 @@ import { hasDevModeCache, isDevMode, getDevModeCache, writeDevModeCache } from '
 type Callback = (...args: any[]) => void;
 
 export class LocalPresence implements Presence {
-    public subscriptions = new EventEmitter();
+    public subscriptions: EventEmitter = new EventEmitter();
 
     public data: {[roomName: string]: string[]} = {};
     public hash: {[roomName: string]: {[key: string]: string}} = {};

--- a/packages/core/test/strict-declarations.ts
+++ b/packages/core/test/strict-declarations.ts
@@ -1,0 +1,54 @@
+import {
+  type Client,
+  Room,
+  room,
+  type RoomOptions,
+} from '@colyseus/core';
+import {
+  OnCreateException,
+  OnDropException,
+  OnJoinException,
+  OnLeaveException,
+  OnReconnectException,
+} from '@colyseus/core/errors/RoomExceptions';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+interface StrictRoomOptions extends RoomOptions {
+  state: { count: number };
+  client: Client;
+}
+
+class StrictRoom extends Room<StrictRoomOptions> {
+  override onCreate(options: { seed: string }) {}
+  override onJoin(client: Client, options?: { name: string }, auth?: { id: string }) {}
+  override onLeave(client: Client, code?: 4000 | 4001) {}
+  override onDrop(client: Client, code?: 4002 | 4003) {}
+  override onReconnect(client: Client) {}
+}
+
+type HookInference = [
+  Expect<Equal<OnCreateException<StrictRoom>['options'], { seed: string }>>,
+  Expect<Equal<OnJoinException<StrictRoom>['client'], Client>>,
+  Expect<Equal<OnJoinException<StrictRoom>['options'], { name: string } | undefined>>,
+  Expect<Equal<OnJoinException<StrictRoom>['auth'], { id: string } | undefined>>,
+  Expect<Equal<OnLeaveException<StrictRoom>['client'], Client>>,
+  Expect<Equal<OnLeaveException<StrictRoom>['consented'], 4000 | 4001 | undefined>>,
+  Expect<Equal<OnDropException<StrictRoom>['client'], Client>>,
+  Expect<Equal<OnDropException<StrictRoom>['code'], 4002 | 4003 | undefined>>,
+  Expect<Equal<OnReconnectException<StrictRoom>['client'], Client>>,
+];
+
+const FunctionalRoom = room<StrictRoomOptions>({
+  state: () => ({ count: 0 }),
+  onCreate(options: { seed: string }) {
+    this.state.count = options.seed.length;
+  },
+});
+const functionalRoom: Room<StrictRoomOptions> = new FunctionalRoom();
+
+void (0 as unknown as HookInference);
+void functionalRoom;


### PR DESCRIPTION
## Summary

- preserve `Room` lifecycle override inference while handling optional hooks in exception declarations
- prevent `LocalPresence.subscriptions` from leaking an invalid inferred `EventEmitter<[never]>` type
- constrain the functional `room()` helper generic to `RoomOptions`
- add a strict NodeNext declaration regression covering the generated package output

## Verification

- `pnpm run build`
- `pnpm --filter @colyseus/core test`
- packed `@colyseus/core` and the schema fix from colyseus/schema#227 into a fresh TypeScript 5.9.3 NodeNext consumer with `strict: true` and `skipLibCheck: false`
- runtime import smoke test for `Room` and `LocalPresence`

The recursive workspace test command remains blocked in an unrelated workspace because its `vitest` executable is unavailable; the root build, focused core test, packed declaration consumer, and runtime smoke test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
