### PR TITLE
allowReconnection and findOneRoomAvailable document arguments they do not take

### DIFF
--- a/packages/core/src/MatchMaker.ts
+++ b/packages/core/src/MatchMaker.ts
@@ -326,7 +326,7 @@ export async function query<T extends Room = any>(
  *
  * @param roomName - The Id of the specific room.
  * @param filterOptions - Filter options.
- * @param sortOptions - Sorting options.
+ * @param additionalSortOptions - Sorting options, merged over the ones declared on the room handler.
  *
  * @returns Promise<IRoomCache> - A promise contaning an object which includes room metadata and configurations.
  */

--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -1308,7 +1308,7 @@ export class Room<T extends RoomOptions = RoomOptions> {
    * Allow the specified client to reconnect into the room. Must be used inside `onLeave()` method.
    * If seconds is provided, the reconnection is going to be cancelled after the provided amount of seconds.
    *
-   * @param client - The client that is allowed to reconnect into the room.
+   * @param previousClient - The client that is allowed to reconnect into the room.
    * @param seconds - The time in seconds that the client is allowed to reconnect into the room.
    *
    * @returns Deferred<Client> - The differed is a promise like type.


### PR DESCRIPTION
Was tracing the reconnection flow and my editor showed `allowReconnection` taking a `client`, which it does not, the argument is `previousClient`. The same block ships in `@colyseus/core@0.17.49` under `build/Room.d.ts`, so that tooltip is wrong wherever anyone hovers it.

`findOneRoomAvailable` is the messier one. The block says `sortOptions`, the argument is `additionalSortOptions`, and there is a local `sortOptions` a few lines down holding the handler defaults with the argument merged over them. So the documented name points at a different value than the one you pass in. I reworded that description line instead of only renaming it, since a bare rename still reads as if it were the final sort order.

Raising this against your note about cosmetic patches: both names reach users through editor tooltips and the generated docs, and one of them collides with a different value inside the same function.
